### PR TITLE
feat: add --nice flag for CPU throttling during indexing

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -183,6 +183,31 @@ Incremental mode is much faster because it:
 4. Deletes index entries for deleted files
 5. Resolves cross-file edges for changed symbols
 
+### CPU Throttling
+
+Indexing large codebases can peg the CPU and make your machine unresponsive. Use `--nice` to lower the process scheduling priority so the OS deprioritizes tessera when other processes need CPU:
+
+```bash
+# Lowest priority — other processes always get CPU first
+tessera index /path/to/project --nice 19
+
+# Moderate throttle
+tessera index /path/to/project --nice 10
+```
+
+Values range from 1 (slight deprioritization) to 19 (lowest priority). The default is off (normal priority).
+
+You can also set this via the `TESSERA_NICE` environment variable so it applies to every index run without passing the flag:
+
+```bash
+export TESSERA_NICE=19
+tessera index /path/to/project  # automatically runs at nice 19
+```
+
+The `--nice` flag takes precedence over the environment variable if both are set.
+
+**Note:** `--nice` uses `os.nice()` which adjusts kernel scheduling priority. The process can still use 100% CPU if nothing else needs it — it just yields immediately when other processes compete. This is usually the right behavior: index as fast as possible when idle, stay out of the way when busy.
+
 ### Verbose Logging
 
 Enable debug logging to see file-by-file progress:
@@ -605,6 +630,7 @@ Tessera automatically upgrades old schema versions on startup.
 4. **Reindex after major refactors** — Parser behavior may have changed; force reindex to keep index accurate
 5. **Monitor stale warnings** — Upgrade stale indexes promptly with `force=True` reindex
 6. **Backup before major upgrades** — If you're using Tessera in production, back up `~/.tessera` before upgrading to a new major version
+7. **Use `--nice 19` for background indexing** — Keeps your machine responsive when indexing large projects alongside other work. Set `TESSERA_NICE=19` in your shell profile to make it the default
 
 ## FAQ
 

--- a/src/tessera/__main__.py
+++ b/src/tessera/__main__.py
@@ -8,10 +8,33 @@ Supports:
 import argparse
 import asyncio
 import logging
+import os
 import sys
 import time
 
 from .server import run_server
+
+
+def _apply_cpu_priority(nice_value: int | None) -> None:
+    """Lower process CPU priority via os.nice().
+
+    Args:
+        nice_value: Nice increment (1-19). Higher = lower priority.
+                    None means no change. 19 is the lowest priority.
+    """
+    if nice_value is None:
+        return
+    nice_value = max(1, min(19, nice_value))
+    try:
+        actual = os.nice(nice_value)
+        logging.getLogger(__name__).info(f"CPU priority: nice {actual}")
+    except PermissionError:
+        logging.getLogger(__name__).warning(
+            f"Could not set nice value {nice_value} (permission denied). "
+            "Running at normal priority."
+        )
+    except OSError as exc:
+        logging.getLogger(__name__).warning(f"Could not set nice value: {exc}")
 
 
 def _run_index(args) -> int:
@@ -23,6 +46,20 @@ def _run_index(args) -> int:
         logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s: %(message)s")
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    # Apply CPU priority before any heavy work.
+    # --nice flag takes precedence, then TESSERA_NICE env var.
+    nice_value = args.nice
+    if nice_value is None:
+        env_nice = os.environ.get("TESSERA_NICE")
+        if env_nice is not None:
+            try:
+                nice_value = int(env_nice)
+            except ValueError:
+                logging.getLogger(__name__).warning(
+                    f"Ignoring invalid TESSERA_NICE={env_nice!r} (must be integer 1-19)"
+                )
+    _apply_cpu_priority(nice_value)
 
     project_path = args.path
 
@@ -92,6 +129,15 @@ def main() -> int:
         "--incremental",
         action="store_true",
         help="Only re-index files changed since last indexed commit"
+    )
+    index_parser.add_argument(
+        "--nice",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Lower CPU scheduling priority (1-19, default: off). "
+             "19 = lowest priority, keeps machine responsive during indexing. "
+             "Equivalent to running `nice -n N tessera index ...`"
     )
     index_parser.add_argument(
         "-v", "--verbose",


### PR DESCRIPTION
## Summary

- Adds `--nice N` flag to `tessera index` that calls `os.nice()` to lower CPU scheduling priority (1-19)
- Adds `TESSERA_NICE` environment variable as a persistent default (flag takes precedence)
- Values are clamped to 1-19, errors (e.g., permission denied) are logged as warnings and indexing continues normally
- Documents the feature in `docs/indexing.md` with usage examples and best practices

## Why

Indexing large codebases pegs the CPU and makes the machine unresponsive for other work. Users currently have to remember to wrap the command with `nice -n 19` externally. A built-in flag is more discoverable and the env var makes it easy to set-and-forget.

This came up when indexing a large WordPress plugin ecosystem (~dozens of repos) — the machine became unusable during indexing. `nice -n 19` solved it immediately, but having to remember that every time is friction that belongs in the tool itself.

## Implementation

- `_apply_cpu_priority()` helper in `__main__.py` wraps `os.nice()` with validation and error handling
- `--nice` CLI arg on the `index` subcommand
- `TESSERA_NICE` env var fallback (checked when `--nice` is not passed)
- Cross-platform: `os.nice()` works on macOS, Linux, and most Unix systems. On Windows it's a no-op (Python raises `OSError`, which we catch and warn about)

## Suggestions for defaults

A few ideas for consideration:

1. **Default to `--nice 10` for CLI indexing** — most users index from the terminal while doing other work. Normal priority is rarely what they want.
2. **Add `--nice` to the `reindex` MCP tool** — when agents trigger reindexing, it shouldn't starve the user's other processes.
3. **Config file support** — a `~/.tessera/config.toml` with `nice = 19` would be even more discoverable than the env var.

## Test plan

- [ ] `tessera index /path --nice 19` — verify `os.nice()` is called, process runs at low priority
- [ ] `TESSERA_NICE=10 tessera index /path` — verify env var is respected
- [ ] `tessera index /path --nice 5` with `TESSERA_NICE=19` — verify flag wins
- [ ] `tessera index /path` without flag or env var — verify no priority change
- [ ] `TESSERA_NICE=abc tessera index /path` — verify warning logged, indexing continues