### PR TITLE
[codex] Improve graph resolution, MCP adoption, and retrieval quality

### DIFF
--- a/benchmarks/competitive-2026-07-14.json
+++ b/benchmarks/competitive-2026-07-14.json
@@ -1,0 +1,5038 @@
+{
+  "graph_resolution": {
+    "cases": [
+      {
+        "caller_file": "caller_alias.py",
+        "caller_symbol": "caller_alias",
+        "name": "python_named_alias",
+        "target_file": "service.py",
+        "target_symbol": "run"
+      },
+      {
+        "caller_file": "caller_module.py",
+        "caller_symbol": "caller_module",
+        "name": "python_module_call",
+        "target_file": "service.py",
+        "target_symbol": "run"
+      },
+      {
+        "caller_file": "caller_reexport.py",
+        "caller_symbol": "caller_reexport",
+        "name": "python_reexport",
+        "target_file": "service.py",
+        "target_symbol": "run"
+      },
+      {
+        "caller_file": "caller_alias.ts",
+        "caller_symbol": "callerAlias",
+        "name": "typescript_named_alias",
+        "target_file": "service.ts",
+        "target_symbol": "run"
+      }
+    ],
+    "codegraph": {
+      "cold_index_ms": 571.84,
+      "passed": 3,
+      "passes": {
+        "python_module_call": true,
+        "python_named_alias": false,
+        "python_reexport": true,
+        "typescript_named_alias": true
+      },
+      "resolved_targets": {
+        "caller_alias.py:caller_alias": [
+          "unrelated.py",
+          "execute"
+        ],
+        "caller_alias.ts:callerAlias": [
+          "service.ts",
+          "run"
+        ],
+        "caller_module.py:caller_module": [
+          "service.py",
+          "run"
+        ],
+        "caller_reexport.py:caller_reexport": [
+          "service.py",
+          "run"
+        ]
+      },
+      "total": 4
+    },
+    "tessera": {
+      "cold_index_ms": 48.51,
+      "passed": 4,
+      "passes": {
+        "python_module_call": true,
+        "python_named_alias": true,
+        "python_reexport": true,
+        "typescript_named_alias": true
+      },
+      "resolved_targets": {
+        "caller_alias.py:caller_alias": [
+          "service.py",
+          "run"
+        ],
+        "caller_alias.ts:callerAlias": [
+          "service.ts",
+          "run"
+        ],
+        "caller_module.py:caller_module": [
+          "service.py",
+          "run"
+        ],
+        "caller_reexport.py:caller_reexport": [
+          "service.py",
+          "run"
+        ]
+      },
+      "total": 4
+    }
+  },
+  "limitations": [
+    "CodeGraph does not index Markdown/document content; unsupported rows are excluded.",
+    "Tessera runs in-process while CodeGraph launches a CLI process per query; latency is directional.",
+    "Ground truth is curated and file-level; it does not score answer synthesis or snippet quality.",
+    "Cached indexes are used unless --reindex is supplied, so setup_ms is not a cold-index benchmark."
+  ],
+  "metadata": {
+    "codegraph_version": "1.4.1",
+    "embedding_model": "BAAI/bge-small-en-v1.5",
+    "generated_at": "2026-07-14T05:10:25.144042+00:00",
+    "measured_query_runs": 139,
+    "platform": "macOS-15.5-arm64-arm-64bit-Mach-O",
+    "python": "3.14.3",
+    "query_cases": 58,
+    "reranking_model": "jinaai/jina-reranker-v1-tiny-en",
+    "tessera_revision": "e71e684579128e172fd3f65202852806b4a1c248",
+    "tier": "full",
+    "top_k": 10
+  },
+  "queries": [
+    {
+      "category": "code",
+      "description": "Find the Image component implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "image-component.tsx",
+        "image-external.tsx",
+        "image-optimizer.ts",
+        "image.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": 121.36,
+      "query": "image optimization component",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/shared/lib/image-loader.ts",
+        "packages/next/src/client/legacy/image.tsx",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/lib/mime-type.ts",
+        "packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts",
+        "packages/next/src/api/og.ts",
+        "packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/client/request/search-params.browser.prod.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find the Image component implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "image-component.tsx",
+        "image-external.tsx",
+        "image-optimizer.ts",
+        "image.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": 1045.13,
+      "query": "image optimization component",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/shared/lib/image-loader.ts",
+        "packages/next/src/client/legacy/image.tsx",
+        "packages/next/src/shared/lib/image-external.tsx",
+        "packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts",
+        "packages/next/src/server/config-shared.ts",
+        "packages/next/src/shared/lib/get-img-props.ts",
+        "packages/next/src/lib/mime-type.ts",
+        "packages/next/src/api/og.ts",
+        "packages/next/src/shared/lib/match-local-pattern.ts",
+        "packages/next/src/shared/lib/image-config.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find the Image component implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "image-component.tsx",
+        "image-external.tsx",
+        "image-optimizer.ts",
+        "image.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": 5553.24,
+      "query": "image optimization component",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/client/image-component.tsx",
+        "packages/next/src/client/legacy/image.tsx",
+        "packages/next/src/server/load-components.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find middleware URL rewrite logic",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "next-url.ts",
+        "next-request.ts",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 156.39,
+      "query": "middleware request rewriting",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/server/web/types.ts",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/client/components/navigation.test.ts",
+        "packages/next/src/client/request/search-params.browser.prod.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/client/components/readonly-url-search-params.ts",
+        "packages/next/src/server/internal-utils.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find middleware URL rewrite logic",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "next-url.ts",
+        "next-request.ts",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 1193.6,
+      "query": "middleware request rewriting",
+      "rank": 6,
+      "reciprocal_rank": 0.1667,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/server/lib/patch-set-header.ts",
+        "packages/next/src/experimental/testing/server/index.ts",
+        "packages/next/src/server/web/types.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.ts",
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts",
+        "packages/next/src/client/route-params.ts",
+        "packages/next/src/server/server-route-utils.ts",
+        "packages/next/src/next-devtools/server/middleware-response.ts",
+        "packages/next/src/experimental/testmode/fetch.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find middleware URL rewrite logic",
+      "engine": "codegraph",
+      "expected_files": [
+        "next-url.ts",
+        "next-request.ts",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4734.89,
+      "query": "middleware request rewriting",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/compiled/@edge-runtime/primitives/load.js",
+        "packages/next/src/server/web/error.ts",
+        "packages/next/src/server/web/adapter.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find route handler implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "app-route/module.ts",
+        "auto-implement-methods.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 37.41,
+      "query": "route handler HTTP methods",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/server/route-modules/app-route/helpers/auto-implement-methods.ts",
+        "packages/next/src/server/base-server.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/lib/url.ts",
+        "packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts",
+        "packages/next/src/server/render.tsx"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find route handler implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "app-route/module.ts",
+        "auto-implement-methods.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 963.59,
+      "query": "route handler HTTP methods",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/server/route-modules/app-route/helpers/auto-implement-methods.ts",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/experimental/testmode/playwright/page-route.ts",
+        "packages/next/src/server/route-modules/app-route/module.ts",
+        "packages/next/src/server/lib/router-server.ts",
+        "packages/next/src/server/request-meta.ts",
+        "packages/next/src/client/resolve-href.ts",
+        "packages/next/src/server/route-modules/route-module.ts",
+        "packages/next/src/server/base-server.ts",
+        "packages/next/src/shared/lib/router/utils/resolve-rewrites.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find route handler implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "app-route/module.ts",
+        "auto-implement-methods.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4428.55,
+      "query": "route handler HTTP methods",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/server/dev/turbopack-utils.ts",
+        "packages/next/src/server/web/edge-route-module-wrapper.ts"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find env var configuration docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "environment-variables.mdx",
+        "env.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 33.57,
+      "query": "how to configure environment variables",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/01-app/02-guides/environment-variables.mdx",
+        "docs/02-pages/02-guides/environment-variables.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/env.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx",
+        "docs/02-pages/04-api-reference/04-config/01-next-config-js/env.mdx",
+        "docs/01-app/01-getting-started/03-layouts-and-pages.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/exportPathMap.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find env var configuration docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "environment-variables.mdx",
+        "env.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 960.4,
+      "query": "how to configure environment variables",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/06-configuring/index.mdx",
+        "docs/01-app/02-guides/environment-variables.mdx",
+        "docs/02-pages/02-guides/environment-variables.mdx",
+        "docs/02-pages/04-api-reference/04-config/01-next-config-js/env.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/env.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/01-getting-started/05-server-and-client-components.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx",
+        "docs/02-pages/04-api-reference/01-components/image-legacy.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find env var configuration docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "environment-variables.mdx",
+        "env.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "how to configure environment variables",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find deployment documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "deploying.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 34.24,
+      "query": "deploying Next.js application",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/02-pages/01-getting-started/11-deploying.mdx",
+        "docs/01-app/01-getting-started/17-deploying.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx",
+        "docs/01-app/02-guides/self-hosting.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/incrementalCacheHandlerPath.mdx",
+        "docs/02-pages/03-building-your-application/index.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/02-pages/02-guides/migrating/index.mdx",
+        "docs/01-app/02-guides/migrating/index.mdx",
+        "package.json"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find deployment documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "deploying.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 774.91,
+      "query": "deploying Next.js application",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/01-app/01-getting-started/17-deploying.mdx",
+        "docs/02-pages/01-getting-started/11-deploying.mdx",
+        "docs/01-app/02-guides/self-hosting.mdx",
+        "docs/01-app/02-guides/single-page-applications.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/assetPrefix.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx",
+        "docs/01-app/02-guides/local-development.mdx",
+        "docs/01-app/01-getting-started/01-installation.mdx",
+        "docs/01-app/02-guides/caching.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find deployment documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "deploying.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "deploying Next.js application",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find server actions code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "action-handler.ts",
+        "server-action-reducer.ts",
+        "serverActions.mdx",
+        "forms-and-mutations.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 24.67,
+      "query": "server actions form submission",
+      "rank": 5,
+      "reciprocal_rank": 0.2,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "docs/01-app/01-getting-started/08-updating-data.mdx",
+        "docs/01-app/02-guides/forms.mdx",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+        "packages/next/src/client/components/navigation.react-server.ts",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/02-pages/04-api-reference/01-components/form.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find server actions code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "action-handler.ts",
+        "server-action-reducer.ts",
+        "serverActions.mdx",
+        "forms-and-mutations.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 870.35,
+      "query": "server actions form submission",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/03-data-fetching/03-forms-and-mutations.mdx",
+        "docs/01-app/01-getting-started/08-updating-data.mdx",
+        "docs/02-pages/02-guides/forms.mdx",
+        "docs/01-app/02-guides/forms.mdx",
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx",
+        "packages/next/src/server/app-render/action-handler.ts",
+        "packages/next/src/server/mcp/tools/get-server-action-by-id.ts",
+        "packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts",
+        "packages/next/src/client/components/router-reducer/router-reducer.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find server actions code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "action-handler.ts",
+        "server-action-reducer.ts",
+        "serverActions.mdx",
+        "forms-and-mutations.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "server actions form submission",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find dynamic routing code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "dynamic-routes.mdx",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 34.63,
+      "query": "dynamic route parameters slugs",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "docs/02-pages/03-building-your-application/01-routing/02-dynamic-routes.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "packages/next/src/shared/lib/router/utils/as-path-to-search-params.ts",
+        "docs/02-pages/03-building-your-application/01-routing/07-api-routes.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/route-params.ts",
+        "docs/02-pages/04-api-reference/03-functions/use-search-params.mdx",
+        "docs/01-app/03-api-reference/04-functions/generate-static-params.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find dynamic routing code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "dynamic-routes.mdx",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 887.7,
+      "query": "dynamic route parameters slugs",
+      "rank": 5,
+      "reciprocal_rank": 0.2,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "packages/next/src/shared/lib/router/utils/is-dynamic.test.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/route.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "packages/next/src/lib/metadata/get-metadata-route.ts",
+        "docs/02-pages/03-building-your-application/01-routing/02-dynamic-routes.mdx",
+        "docs/02-pages/03-building-your-application/01-routing/07-api-routes.mdx",
+        "docs/02-pages/04-api-reference/03-functions/use-params.mdx",
+        "packages/next/src/client/page-loader.ts",
+        "docs/01-app/03-api-reference/04-functions/generate-static-params.mdx",
+        "packages/next/src/shared/lib/router/utils/sorted-routes.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find dynamic routing code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "dynamic-routes.mdx",
+        "middleware-route-matcher.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "dynamic route parameters slugs",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "code",
+      "description": "Find webpack build config",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "webpack-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 30.85,
+      "query": "webpack compiler configuration",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/next-devtools.webpack-config.js",
+        "packages/next/next-runtime.webpack-config.js",
+        "packages/next/src/lib/turbopack-warning.ts",
+        "packages/next/src/server/config-shared.ts",
+        "packages/next/src/bundles/webpack/bundle5.js",
+        "packages/next/taskfile-webpack.js",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/client/request/search-params.browser.ts",
+        "packages/next/src/server/config-utils.ts",
+        "packages/next/src/server/dev/hot-reloader-webpack.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find webpack build config",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "webpack-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 872.54,
+      "query": "webpack compiler configuration",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/taskfile-webpack.js",
+        "packages/next/src/server/dev/hot-middleware.ts",
+        "packages/next/next-devtools.webpack-config.js",
+        "packages/next/src/server/dev/on-demand-entry-handler.ts",
+        "packages/next/src/server/config-utils.ts",
+        "packages/next/src/server/config-shared.ts",
+        "packages/next/src/bundles/webpack/packages/FetchCompileWasmTemplatePlugin.js",
+        "packages/next/src/bundles/webpack/packages/FetchCompileWasmPlugin.js",
+        "packages/next/src/lib/turbopack-warning.ts",
+        "packages/next/src/server/dev/hot-reloader-types.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find webpack build config",
+      "engine": "codegraph",
+      "expected_files": [
+        "webpack-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4407.8,
+      "query": "webpack compiler configuration",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/compiled/webpack/webpack.d.ts",
+        "packages/next/src/bundles/webpack/packages/webpack.d.ts",
+        "packages/next/src/compiled/@modelcontextprotocol/sdk/server/mcp.js"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find HMR client implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "hot-reloader-webpack.ts",
+        "hot-reloader-turbopack.ts",
+        "hmr-refresh-reducer.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 25.23,
+      "query": "hot module replacement client",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/bundles/webpack/packages/lazy-compilation-node.js",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/server/internal-utils.ts",
+        "packages/next/src/client/components/navigation.react-server.ts",
+        "packages/next/src/lib/url.ts",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/client/request/search-params.browser.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find HMR client implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "hot-reloader-webpack.ts",
+        "hot-reloader-turbopack.ts",
+        "hmr-refresh-reducer.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 842.55,
+      "query": "hot module replacement client",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/bundles/webpack/packages/lazy-compilation-node.js",
+        "packages/next/navigation.js",
+        "packages/next/client.js",
+        "packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts",
+        "packages/next/src/client/page-bootstrap.ts",
+        "packages/next/src/client/dev/hot-middleware-client.ts",
+        "packages/next/src/client/next-dev-turbopack.ts",
+        "packages/next/src/server/dev/hot-reloader-rspack.ts",
+        "packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx",
+        "packages/next/src/server/dev/serialized-errors.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find HMR client implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "hot-reloader-webpack.ts",
+        "hot-reloader-turbopack.ts",
+        "hmr-refresh-reducer.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4437.88,
+      "query": "hot module replacement client",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/taskfile.js",
+        "packages/next/src/compiled/jsonwebtoken/index.js"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find cookie handling utilities",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "cookies.ts",
+        "get-cookie-parser.ts",
+        "request-cookies.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 25.61,
+      "query": "cookie parsing and setting",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/web/spec-extension/cookies.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/server/api-utils/get-cookie-parser.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts",
+        "packages/next/src/server/web/spec-extension/adapters/request-cookies.ts",
+        "packages/next/src/client/components/navigation.test.ts",
+        "packages/next/src/client/request/search-params.browser.prod.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find cookie handling utilities",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "cookies.ts",
+        "get-cookie-parser.ts",
+        "request-cookies.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 848.35,
+      "query": "cookie parsing and setting",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/shared/lib/i18n/get-locale-redirect.ts",
+        "packages/next/src/server/api-utils/get-cookie-parser.ts",
+        "packages/next/src/server/web/utils.test.ts",
+        "packages/next/src/server/base-http/index.ts",
+        "packages/next/src/server/api-utils/node/api-resolver.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/server/web/spec-extension/response.ts",
+        "packages/next/src/server/lib/patch-set-header.ts",
+        "packages/next/src/server/web/spec-extension/cookies.ts",
+        "packages/next/src/server/request/cookies.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find cookie handling utilities",
+      "engine": "codegraph",
+      "expected_files": [
+        "cookies.ts",
+        "get-cookie-parser.ts",
+        "request-cookies.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4557.92,
+      "query": "cookie parsing and setting",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/compiled/comment-json/index.js"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find static generation logic",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 92.69,
+      "query": "static page generation at build time",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/app-render/app-render.tsx",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts",
+        "packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/components/navigation.test.ts",
+        "packages/next/src/server/mcp/tools/get-page-metadata.ts",
+        "packages/next/src/client/components/segment-cache/navigation.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find static generation logic",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 774.76,
+      "query": "static page generation at build time",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx",
+        "packages/next/src/types.ts",
+        "packages/next/src/server/load-components.ts",
+        "packages/next/src/export/routes/app-page.ts",
+        "packages/next/src/server/lib/patch-fetch.ts",
+        "packages/next/src/server/config-shared.ts",
+        "packages/next/src/server/mcp/tools/get-page-metadata.ts",
+        "packages/next/src/shared/lib/turbopack/manifest-loader.ts",
+        "packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts",
+        "packages/next/src/export/worker.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find static generation logic",
+      "engine": "codegraph",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 4470.12,
+      "query": "static page generation at build time",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/compiled/mini-css-extract-plugin/index.js"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find error boundary implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "error-boundary.tsx",
+        "not-found.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 36.71,
+      "query": "error boundary fallback component",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/app-render/app-render.tsx",
+        "packages/next/src/server/lib/implicit-tags.test.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/utils/get-dynamic-param.ts",
+        "packages/next/src/client/components/navigation.react-server.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/shared/lib/router/utils/parse-relative-url.ts",
+        "packages/next/src/lib/typescript/diagnosticFormatter.ts",
+        "packages/next/src/lib/metadata/resolvers/resolve-url.test.ts",
+        "packages/next/src/server/internal-utils.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find error boundary implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "error-boundary.tsx",
+        "not-found.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 920.23,
+      "query": "error boundary fallback component",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/client/components/http-access-fallback/error-boundary.tsx",
+        "packages/next/src/client/components/http-access-fallback/error-fallback.tsx",
+        "packages/next/src/client/components/builtin/not-found.tsx",
+        "packages/next/src/client/components/builtin/global-not-found.tsx",
+        "packages/next/src/client/components/error-boundary.tsx",
+        "packages/next/src/client/components/layout-router.tsx",
+        "packages/next/src/shared/lib/router/utils/get-dynamic-param.ts",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/server/lib/implicit-tags.test.ts",
+        "packages/next/src/lib/metadata/resolvers/resolve-url.test.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find error boundary implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "error-boundary.tsx",
+        "not-found.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4570.33,
+      "query": "error boundary fallback component",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/client/components/http-access-fallback/error-boundary.tsx",
+        "packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx",
+        "packages/next/src/next-devtools/userspace/pages/pages-dev-overlay-error-boundary.tsx",
+        "packages/next/src/shared/lib/no-fallback-error.external.ts",
+        "packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.stories.tsx",
+        "packages/next/src/next-devtools/userspace/pages/pages-dev-overlay-setup.tsx",
+        "packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find Link prefetch behavior",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "link.tsx",
+        "prefetch.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 90.33,
+      "query": "link component prefetching logic",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/client/link.tsx",
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/components/segment-cache/navigation.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/client/components/navigation.test.ts",
+        "packages/next/src/server/internal-utils.ts",
+        "packages/next/src/next-devtools/dev-overlay/utils/parse-url-from-text.ts",
+        "packages/next/src/client/page-loader.ts",
+        "packages/next/src/client/components/app-router.tsx"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find Link prefetch behavior",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "link.tsx",
+        "prefetch.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 810.65,
+      "query": "link component prefetching logic",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/client/components/app-router-utils.ts",
+        "packages/next/src/client/components/segment-cache/prefetch.ts",
+        "packages/next/src/client/components/app-router.tsx",
+        "packages/next/src/client/components/segment-cache/navigation.ts",
+        "packages/next/src/client/app-link-gc.ts",
+        "packages/next/src/client/app-dir/link.tsx",
+        "packages/next/src/lib/metadata/generate/alternate.tsx",
+        "packages/next/src/client/link.tsx",
+        "packages/next/src/next-devtools/dev-overlay/components/hot-linked-text/index.tsx",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find Link prefetch behavior",
+      "engine": "codegraph",
+      "expected_files": [
+        "link.tsx",
+        "prefetch.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4411.46,
+      "query": "link component prefetching logic",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/client/link.tsx",
+        "packages/next/src/client/page-loader.ts",
+        "packages/next/src/compiled/react/cjs/react.development.js",
+        "packages/next/src/shared/lib/router/router.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find API route body parser",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "api-resolver.ts",
+        "parse-body.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 36.12,
+      "query": "API route request body parsing",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/app-render/action-handler.ts",
+        "packages/next/src/server/base-server.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/shared/lib/router/utils/parse-relative-url.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts",
+        "packages/next/src/lib/url.ts",
+        "packages/next/src/client/page-loader.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find API route body parser",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "api-resolver.ts",
+        "parse-body.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 868.1,
+      "query": "API route request body parsing",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/api-utils/node/api-resolver.ts",
+        "packages/next/src/server/base-server.ts",
+        "packages/next/src/server/lib/implicit-tags.test.ts",
+        "packages/next/src/experimental/testing/server/config-testing-utils.ts",
+        "packages/next/src/server/api-utils/node/parse-body.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/shared/lib/router/utils/route-matcher.ts",
+        "packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts",
+        "packages/next/src/experimental/testmode/playwright/page-route.ts",
+        "packages/next/src/client/route-params.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find API route body parser",
+      "engine": "codegraph",
+      "expected_files": [
+        "api-resolver.ts",
+        "parse-body.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4465.97,
+      "query": "API route request body parsing",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/base-http/web.ts",
+        "packages/next/src/compiled/comment-json/index.js"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find caching documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "caching-and-revalidating.mdx",
+        "caching.mdx",
+        "revalidatePath.mdx",
+        "revalidateTag.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 80.81,
+      "query": "caching and revalidation strategies",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/02-guides/caching.mdx",
+        "docs/01-app/03-api-reference/04-functions/cacheLife.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx",
+        "docs/01-app/01-getting-started/09-caching-and-revalidating.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "package.json",
+        "docs/01-app/03-api-reference/04-functions/cacheTag.mdx",
+        "docs/01-app/04-glossary.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find caching documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "caching-and-revalidating.mdx",
+        "caching.mdx",
+        "revalidatePath.mdx",
+        "revalidateTag.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 770.88,
+      "query": "caching and revalidation strategies",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/04-functions/revalidateTag.mdx",
+        "docs/01-app/01-getting-started/06-cache-components.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/headers.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx",
+        "docs/01-app/01-getting-started/09-caching-and-revalidating.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/staleTimes.mdx",
+        "docs/01-app/03-api-reference/04-functions/fetch.mdx",
+        "docs/01-app/03-api-reference/04-functions/cacheLife.mdx",
+        "docs/02-pages/03-building-your-application/03-data-fetching/05-client-side.mdx",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find caching documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "caching-and-revalidating.mdx",
+        "caching.mdx",
+        "revalidatePath.mdx",
+        "revalidateTag.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "caching and revalidation strategies",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find i18n docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "internationalization.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 28.88,
+      "query": "internationalization and locales",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/02-guides/internationalization.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx",
+        "docs/02-pages/02-guides/internationalization.mdx",
+        "docs/01-app/03-api-reference/04-functions/next-request.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx",
+        "docs/02-pages/04-api-reference/03-functions/use-search-params.mdx",
+        "packages/next/package.json",
+        "turbo.json"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find i18n docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "internationalization.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 884.97,
+      "query": "internationalization and locales",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/02-guides/internationalization.mdx",
+        "docs/02-pages/02-guides/internationalization.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx",
+        "docs/01-app/03-api-reference/04-functions/next-request.mdx",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/01-metadata/sitemap.mdx",
+        "turbo.json",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/headers.mdx",
+        "packages/next/src/lib/known-edge-safe-packages.json"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find i18n docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "internationalization.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "internationalization and locales",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find middleware config docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 28.42,
+      "query": "middleware matching paths configuration",
+      "rank": 6,
+      "reciprocal_rank": 0.1667,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/server/base-server.ts",
+        "docs/01-app/01-getting-started/16-proxy.mdx",
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.ts",
+        "packages/next/src/experimental/testing/server/config-testing-utils.ts",
+        "packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "packages/next/src/client/components/navigation.test.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find middleware config docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 784.89,
+      "query": "middleware matching paths configuration",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.test.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.ts",
+        "packages/next/src/server/lib/router-utils/filesystem.ts",
+        "packages/next/src/client/app-find-source-map-url.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/proxy.mdx",
+        "packages/next/src/server/base-server.ts",
+        "docs/01-app/01-getting-started/16-proxy.mdx",
+        "packages/next/src/shared/lib/router/utils/route-match-utils.ts",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find middleware config docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "middleware matching paths configuration",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find auth documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "authentication.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 24.97,
+      "query": "authentication and session management",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/02-guides/authentication.mdx",
+        "docs/02-pages/02-guides/authentication.mdx",
+        "docs/01-app/02-guides/redirecting.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-cache-private.mdx",
+        "packages/next/package.json",
+        "docs/01-app/03-api-reference/04-functions/userAgent.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find auth documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "authentication.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 781.17,
+      "query": "authentication and session management",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/02-guides/authentication.mdx",
+        "docs/01-app/03-api-reference/04-functions/unauthorized.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/proxy.mdx",
+        "docs/01-app/02-guides/authentication.mdx",
+        "docs/01-app/02-guides/migrating/from-create-react-app.mdx",
+        "docs/01-app/03-api-reference/02-components/link.mdx",
+        "packages/next/package.json",
+        "packages/next/src/lib/known-edge-safe-packages.json",
+        "docs/01-app/02-guides/data-security.mdx",
+        "docs/01-app/03-api-reference/04-functions/forbidden.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find auth documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "authentication.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "authentication and session management",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find CSS/styling docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "css.mdx",
+        "post-css.mdx",
+        "css-in-js.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 31.27,
+      "query": "CSS modules and styling options",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/01-app/01-getting-started/11-css.mdx",
+        "docs/02-pages/01-getting-started/06-css.mdx",
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/02-pages/02-guides/post-css.mdx",
+        "docs/01-app/03-api-reference/04-functions/generate-viewport.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/cssChunking.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find CSS/styling docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "css.mdx",
+        "post-css.mdx",
+        "css-in-js.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 936.78,
+      "query": "CSS modules and styling options",
+      "rank": 5,
+      "reciprocal_rank": 0.2,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/08-turbopack.mdx",
+        "docs/01-app/03-api-reference/02-components/font.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/not-found.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/cssChunking.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/02-pages/02-guides/post-css.mdx",
+        "packages/next/package.json",
+        "docs/02-pages/01-getting-started/06-css.mdx",
+        "docs/01-app/03-api-reference/04-functions/generate-metadata.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find CSS/styling docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "css.mdx",
+        "post-css.mdx",
+        "css-in-js.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "CSS modules and styling options",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find TypeScript setup docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "typescript.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 32.58,
+      "query": "TypeScript configuration and support",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/05-config/02-typescript.mdx",
+        "packages/next/package.json",
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/page.mdx",
+        "docs/02-pages/04-api-reference/03-functions/use-search-params.mdx",
+        "docs/01-app/01-getting-started/03-layouts-and-pages.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/01-app/03-api-reference/04-functions/generate-static-params.mdx",
+        "docs/01-app/01-getting-started/01-installation.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find TypeScript setup docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "typescript.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 784.61,
+      "query": "TypeScript configuration and support",
+      "rank": 9,
+      "reciprocal_rank": 0.1111,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/01-getting-started/01-installation.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/typedRoutes.mdx",
+        "docs/01-app/02-guides/migrating/from-vite.mdx",
+        "docs/01-app/03-api-reference/08-turbopack.mdx",
+        "docs/03-architecture/supported-browsers.mdx",
+        "docs/02-pages/02-guides/upgrading/version-11.mdx",
+        "docs/01-app/02-guides/testing/cypress.mdx",
+        "docs/02-pages/02-guides/upgrading/version-12.mdx",
+        "docs/01-app/03-api-reference/05-config/02-typescript.mdx",
+        "turbo.json"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find TypeScript setup docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "typescript.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "TypeScript configuration and support",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find error handling docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "error-handling.mdx",
+        "error.mdx",
+        "not-found.mdx",
+        "custom-error.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 30.2,
+      "query": "error handling custom error pages",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/06-configuring/12-error-handling.mdx",
+        "docs/01-app/01-getting-started/02-project-structure.mdx",
+        "docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx",
+        "docs/01-app/02-guides/mcp.mdx",
+        "docs/01-app/01-getting-started/10-error-handling.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-server-side-props.mdx",
+        "package.json",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/page.mdx",
+        "docs/01-app/03-api-reference/05-config/02-typescript.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find error handling docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "error-handling.mdx",
+        "error.mdx",
+        "not-found.mdx",
+        "custom-error.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 893.99,
+      "query": "error handling custom error pages",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/06-configuring/12-error-handling.mdx",
+        "docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-server-side-props.mdx",
+        "docs/01-app/01-getting-started/10-error-handling.mdx",
+        "docs/01-app/01-getting-started/02-project-structure.mdx",
+        "docs/02-pages/03-building-your-application/03-data-fetching/03-get-server-side-props.mdx",
+        "docs/02-pages/02-guides/forms.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/error.mdx",
+        ".gitattributes",
+        "docs/01-app/02-guides/mcp.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find error handling docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "error-handling.mdx",
+        "error.mdx",
+        "not-found.mdx",
+        "custom-error.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "error handling custom error pages",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find config reference docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "next-config-js"
+      ],
+      "language": "typescript",
+      "latency_ms": 85.93,
+      "query": "next.config.js configuration options",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/index.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx",
+        "docs/02-pages/04-api-reference/01-components/image-legacy.mdx",
+        "docs/01-app/02-guides/migrating/from-vite.mdx",
+        "docs/01-app/02-guides/upgrading/version-16.mdx",
+        "docs/01-app/02-guides/migrating/from-create-react-app.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/webpack.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/03-api-reference/05-config/index.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find config reference docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "next-config-js"
+      ],
+      "language": "typescript",
+      "latency_ms": 833.0,
+      "query": "next.config.js configuration options",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/04-api-reference/04-config/01-next-config-js/index.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/index.mdx",
+        "docs/02-pages/04-api-reference/01-components/image-legacy.mdx",
+        "docs/01-app/02-guides/upgrading/version-16.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/typescript.mdx",
+        "docs/01-app/03-api-reference/05-config/index.mdx",
+        "docs/02-pages/03-building-your-application/06-configuring/index.mdx",
+        "docs/02-pages/04-api-reference/04-config/index.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx",
+        "docs/01-app/02-guides/package-bundling.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find config reference docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "next-config-js"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "next.config.js configuration options",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find streaming implementation and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "loading.mdx",
+        "flight-render-result.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 29.78,
+      "query": "streaming and suspense boundaries",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/loading.mdx",
+        "docs/01-app/04-glossary.mdx",
+        "packages/next/src/server/request/search-params.ts",
+        "package.json",
+        "packages/next/package.json",
+        "packages/next/tsconfig.build.json",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "docs/01-app/01-getting-started/06-cache-components.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find streaming implementation and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "loading.mdx",
+        "flight-render-result.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 873.57,
+      "query": "streaming and suspense boundaries",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/04-glossary.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/loading.mdx",
+        "docs/01-app/02-guides/videos.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/02-guides/public-static-pages.mdx",
+        "docs/01-app/01-getting-started/07-fetching-data.mdx",
+        "packages/next/src/lib/metadata/metadata.tsx",
+        "packages/next/package.json",
+        "packages/next/tsconfig.build.json",
+        "docs/01-app/01-getting-started/06-cache-components.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find streaming implementation and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "loading.mdx",
+        "flight-render-result.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "streaming and suspense boundaries",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find parallel routing code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "parallel-routes.mdx",
+        "intercepting-routes.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 38.12,
+      "query": "parallel routes and intercepting routes",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/01-getting-started/02-project-structure.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/intercepting-routes.mdx",
+        "packages/next/src/lib/generate-interception-routes-rewrites.test.ts",
+        "packages/next/src/server/route-definitions/route-definition.ts",
+        "packages/next/src/client/components/segment-cache/navigation.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/parallel-routes.mdx",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/shared/lib/router/utils/sortable-routes.ts",
+        "packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find parallel routing code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "parallel-routes.mdx",
+        "intercepting-routes.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 961.97,
+      "query": "parallel routes and intercepting routes",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/intercepting-routes.mdx",
+        "docs/01-app/01-getting-started/02-project-structure.mdx",
+        "packages/next/src/server/lib/router-utils/route-types-utils.ts",
+        "packages/next/src/server/route-definitions/route-definition.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/parallel-routes.mdx",
+        "packages/next/src/client/components/router-reducer/compute-changed-path.ts",
+        "packages/next/src/lib/generate-interception-routes-rewrites.test.ts",
+        "packages/next/src/shared/lib/router/utils/get-dynamic-param.ts",
+        "packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts",
+        "packages/next/src/shared/lib/router/utils/route-regex.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find parallel routing code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "parallel-routes.mdx",
+        "intercepting-routes.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "parallel routes and intercepting routes",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find metadata system code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "metadata-and-og-images.mdx",
+        "generate-metadata.mdx",
+        "resolve-metadata.ts",
+        "opengraph-image.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 28.34,
+      "query": "metadata and open graph configuration",
+      "rank": 4,
+      "reciprocal_rank": 0.25,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/route.mdx",
+        "packages/next/src/lib/metadata/types/metadata-interface.ts",
+        "packages/next/src/lib/metadata/generate/opengraph.tsx",
+        "docs/01-app/03-api-reference/04-functions/generate-metadata.mdx",
+        "packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts",
+        "packages/next/src/lib/metadata/metadata.tsx",
+        "docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/01-metadata/index.mdx",
+        "docs/04-community/01-contribution-guide.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find metadata system code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "metadata-and-og-images.mdx",
+        "generate-metadata.mdx",
+        "resolve-metadata.ts",
+        "opengraph-image.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 958.27,
+      "query": "metadata and open graph configuration",
+      "rank": 4,
+      "reciprocal_rank": 0.25,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/route.mdx",
+        "packages/next/src/lib/metadata/metadata.tsx",
+        "packages/next/src/lib/metadata/generate/opengraph.tsx",
+        "docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx",
+        "docs/01-app/01-getting-started/14-metadata-and-og-images.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/01-metadata/index.mdx",
+        "docs/01-app/03-api-reference/04-functions/generate-metadata.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx",
+        "packages/next/src/lib/metadata/types/opengraph-types.ts",
+        "packages/next/src/lib/metadata/get-metadata-route.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find metadata system code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "metadata-and-og-images.mdx",
+        "generate-metadata.mdx",
+        "resolve-metadata.ts",
+        "opengraph-image.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "metadata and open graph configuration",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find font optimization code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "fonts.mdx",
+        "font.mdx",
+        "font-utils.ts",
+        "next-font-loader"
+      ],
+      "language": "typescript",
+      "latency_ms": 28.29,
+      "query": "font optimization and loading",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/02-components/font.mdx",
+        "docs/01-app/01-getting-started/13-fonts.mdx",
+        "package.json",
+        "packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx",
+        "packages/next/package.json",
+        "docs/02-pages/02-guides/upgrading/version-13.mdx",
+        "packages/next/src/shared/lib/turbopack/utils.test.ts",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/04-glossary.mdx",
+        "packages/next/src/server/next-server.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find font optimization code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "fonts.mdx",
+        "font.mdx",
+        "font-utils.ts",
+        "next-font-loader"
+      ],
+      "language": "typescript",
+      "latency_ms": 974.06,
+      "query": "font optimization and loading",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/02-components/font.mdx",
+        "docs/01-app/01-getting-started/13-fonts.mdx",
+        "docs/02-pages/02-guides/upgrading/version-13.mdx",
+        "packages/next/src/client/head-manager.ts",
+        "packages/next/src/server/app-render/get-preloadable-fonts.tsx",
+        "packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx",
+        "docs/01-app/03-api-reference/03-file-conventions/not-found.mdx",
+        "packages/next/src/client/components/styles/access-error-styles.ts",
+        "packages/next/src/server/font-utils.ts",
+        "packages/next/src/server/app-render/get-layer-assets.tsx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find font optimization code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "fonts.mdx",
+        "font.mdx",
+        "font-utils.ts",
+        "next-font-loader"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "font optimization and loading",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find ISR implementation and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "incremental-static-regeneration.mdx",
+        "incremental-cache"
+      ],
+      "language": "typescript",
+      "latency_ms": 27.82,
+      "query": "incremental static regeneration ISR",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/02-guides/incremental-static-regeneration.mdx",
+        "docs/01-app/02-guides/incremental-static-regeneration.mdx",
+        "docs/01-app/04-glossary.mdx",
+        "package.json",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/package.json",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "docs/01-app/02-guides/self-hosting.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find ISR implementation and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "incremental-static-regeneration.mdx",
+        "incremental-cache"
+      ],
+      "language": "typescript",
+      "latency_ms": 833.57,
+      "query": "incremental static regeneration ISR",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/04-glossary.mdx",
+        "docs/02-pages/02-guides/incremental-static-regeneration.mdx",
+        "docs/01-app/02-guides/incremental-static-regeneration.mdx",
+        "docs/01-app/02-guides/content-security-policy.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/02-guides/self-hosting.mdx",
+        "docs/01-app/03-api-reference/07-edge.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-static-props.mdx",
+        "docs/02-pages/02-guides/draft-mode.mdx",
+        "packages/next/src/server/request/search-params.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find ISR implementation and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "incremental-static-regeneration.mdx",
+        "incremental-cache"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "incremental static regeneration ISR",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find data fetching code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "data-fetching",
+        "fetch-server-response.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 38.98,
+      "query": "data fetching with fetch API",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/03-data-fetching/05-client-side.mdx",
+        "docs/01-app/01-getting-started/07-fetching-data.mdx",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/02-guides/static-exports.mdx",
+        "docs/02-pages/03-building-your-application/02-rendering/05-client-side-rendering.mdx",
+        "docs/01-app/03-api-reference/05-config/02-typescript.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "docs/02-pages/04-api-reference/03-functions/get-initial-props.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find data fetching code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "data-fetching",
+        "fetch-server-response.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 901.03,
+      "query": "data fetching with fetch API",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/01-getting-started/07-fetching-data.mdx",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/03-api-reference/05-config/02-typescript.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-initial-props.mdx",
+        "docs/02-pages/03-building-your-application/02-rendering/05-client-side-rendering.mdx",
+        "docs/01-app/02-guides/single-page-applications.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "docs/01-app/02-guides/static-exports.mdx",
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "docs/01-app/02-guides/backend-for-frontend.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find data fetching code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "data-fetching",
+        "fetch-server-response.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "data fetching with fetch API",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find client component boundary code and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "server-and-client-components.mdx",
+        "flight-client-entry-plugin.ts",
+        "next-flight-client-entry-loader.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 29.15,
+      "query": "client components use client directive",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/01-directives/use-client.mdx",
+        "docs/01-app/01-getting-started/05-server-and-client-components.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-server.mdx",
+        "packages/next/src/server/typescript/rules/client-boundary.ts",
+        "packages/next/src/lib/format-server-error.ts",
+        "packages/next/src/server/typescript/rules/error.ts",
+        "docs/01-app/02-guides/migrating/from-vite.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/03-api-reference/02-components/form.mdx",
+        "packages/next/src/client/components/client-page.tsx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find client component boundary code and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "server-and-client-components.mdx",
+        "flight-client-entry-plugin.ts",
+        "next-flight-client-entry-loader.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 836.32,
+      "query": "client components use client directive",
+      "rank": 3,
+      "reciprocal_rank": 0.3333,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/01-directives/use-client.mdx",
+        "packages/next/src/server/typescript/rules/error.ts",
+        "docs/01-app/01-getting-started/05-server-and-client-components.mdx",
+        "packages/next/src/server/typescript/rules/client-boundary.ts",
+        "docs/01-app/01-getting-started/08-updating-data.mdx",
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-server.mdx",
+        "docs/01-app/02-guides/static-exports.mdx",
+        "packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find client component boundary code and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "server-and-client-components.mdx",
+        "flight-client-entry-plugin.ts",
+        "next-flight-client-entry-loader.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "client components use client directive",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find redirect implementation and docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "redirecting.mdx",
+        "redirect.ts",
+        "redirect-boundary.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": 85.65,
+      "query": "redirect and permanent redirect",
+      "rank": 4,
+      "reciprocal_rank": 0.25,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx",
+        "docs/01-app/03-api-reference/04-functions/redirect.mdx",
+        "docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx",
+        "docs/01-app/02-guides/redirecting.mdx",
+        "packages/next/src/lib/redirect-status.ts",
+        "packages/next/src/lib/build-custom-route.ts",
+        "packages/next/src/experimental/testing/server/config-testing-utils.ts",
+        "docs/02-pages/04-api-reference/03-functions/get-server-side-props.mdx",
+        "packages/next/src/lib/load-custom-routes.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find redirect implementation and docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "redirecting.mdx",
+        "redirect.ts",
+        "redirect-boundary.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": 774.01,
+      "query": "redirect and permanent redirect",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx",
+        "docs/01-app/03-api-reference/04-functions/redirect.mdx",
+        "packages/next/src/lib/redirect-status.ts",
+        "packages/next/src/client/components/redirect-status-code.ts",
+        "docs/02-pages/04-api-reference/03-functions/get-static-props.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-server-side-props.mdx",
+        "packages/next/src/experimental/testing/server/config-testing-utils.ts",
+        "packages/next/src/client/components/navigation.react-server.ts",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx",
+        "packages/next/src/experimental/testing/server/config-testing-utils.test.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find redirect implementation and docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "redirecting.mdx",
+        "redirect.ts",
+        "redirect-boundary.tsx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "redirect and permanent redirect",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "code",
+      "description": "Find turbopack resolver",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "hot-reloader-turbopack.ts",
+        "middleware-turbopack.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 33.26,
+      "query": "turbopack module resolution",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/server/dev/hot-reloader-webpack.ts",
+        "packages/next/src/server/dev/middleware-turbopack.ts",
+        "packages/next/src/bundles/babel/packages/traverse.js",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/lib/metadata/resolvers/resolve-url.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/shared/lib/turbopack/manifest-loader.ts",
+        "packages/next/src/shared/lib/router/utils/parse-url.ts",
+        "packages/next/src/client/next-turbopack.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find turbopack resolver",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "hot-reloader-turbopack.ts",
+        "middleware-turbopack.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 884.97,
+      "query": "turbopack module resolution",
+      "rank": 10,
+      "reciprocal_rank": 0.1,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/server/route-modules/pages-api/module.compiled.js",
+        "packages/next/src/server/route-modules/pages/module.compiled.js",
+        "packages/next/src/client/next-turbopack.ts",
+        "packages/next/src/server/app-render/segment-explorer-path.ts",
+        "packages/next/taskfile-ncc.js",
+        "packages/next/src/client/next-dev-turbopack.ts",
+        "packages/next/src/server/dev/browser-logs/source-map.ts",
+        "packages/next/src/shared/lib/router/utils/route-match-utils.ts",
+        "packages/next/src/bundles/webpack/bundle5.js",
+        "packages/next/src/server/dev/middleware-turbopack.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find turbopack resolver",
+      "engine": "codegraph",
+      "expected_files": [
+        "hot-reloader-turbopack.ts",
+        "middleware-turbopack.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 5523.03,
+      "query": "turbopack module resolution",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/shared/lib/turbopack/utils.ts",
+        "packages/next/src/server/route-modules/pages-api/module.ts",
+        "packages/next/src/server/lib/module-loader/route-module-loader.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find React Server Component serialization",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "flight-render-result.ts",
+        "parse-and-validate-flight-router-state.tsx",
+        "create-flight-router-state-from-loader-tree.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 77.47,
+      "query": "RSC payload serialization",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/lib/url.ts",
+        "packages/next/src/server/internal-utils.ts",
+        "packages/next/src/server/resume-data-cache/resume-data-cache.test.ts",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts",
+        "packages/next/src/client/route-params.ts",
+        "packages/next/src/shared/lib/router/utils/querystring.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find React Server Component serialization",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "flight-render-result.ts",
+        "parse-and-validate-flight-router-state.tsx",
+        "create-flight-router-state-from-loader-tree.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 799.73,
+      "query": "RSC payload serialization",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/server/app-render/flight-render-result.ts",
+        "packages/next/src/client/route-params.ts",
+        "packages/next/src/server/resume-data-cache/resume-data-cache.test.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/server/resume-data-cache/resume-data-cache.ts",
+        "packages/next/src/server/app-render/get-asset-query-string.ts",
+        "packages/next/src/client/components/segment-cache/cache.ts",
+        "packages/next/src/server/resume-data-cache/cache-store.ts",
+        "packages/next/src/server/request-meta.ts",
+        "packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find React Server Component serialization",
+      "engine": "codegraph",
+      "expected_files": [
+        "flight-render-result.ts",
+        "parse-and-validate-flight-router-state.tsx",
+        "create-flight-router-state-from-loader-tree.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 6490.89,
+      "query": "RSC payload serialization",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/server/app-render/app-render.tsx"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find build tracing implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "trace.test.ts",
+        "upload-trace.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 52.97,
+      "query": "trace file generation for debugging",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/trace/trace-uploader.ts",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "packages/next/src/diagnostics/build-diagnostics.ts",
+        "packages/next/src/diagnostics/build-diagnostics.test.ts",
+        "packages/next/src/server/dev/middleware-turbopack.ts",
+        "packages/next/src/client/app-find-source-map-url.ts",
+        "packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts",
+        "packages/next/src/server/dev/browser-logs/receive-logs.ts",
+        "packages/next/src/server/app-render/app-render.tsx"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find build tracing implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "trace.test.ts",
+        "upload-trace.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 969.03,
+      "query": "trace file generation for debugging",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/trace/upload-trace.ts",
+        "packages/next/src/diagnostics/build-diagnostics.ts",
+        "packages/next/src/trace/trace.test.ts",
+        "packages/next/src/cli/next-analyze.ts",
+        "packages/next/src/trace/trace-uploader.ts",
+        "run-tests.js",
+        "packages/next/src/trace/report/to-json-build.ts",
+        "packages/next/src/server/lib/parse-stack.ts",
+        "packages/next/src/server/image-optimizer.ts",
+        "packages/next/src/client/components/segment-cache/navigation.ts"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find build tracing implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "trace.test.ts",
+        "upload-trace.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 4549.72,
+      "query": "trace file generation for debugging",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/server/lib/trace/tracer.ts",
+        "packages/next/src/compiled/crypto-browserify/index.js"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find migration guide",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "app-router-migration.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 80.51,
+      "query": "upgrading from pages router to app router",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/02-pages/02-guides/upgrading/version-14.mdx",
+        "docs/01-app/02-guides/upgrading/version-16.mdx",
+        "docs/02-pages/02-guides/upgrading/codemods.mdx",
+        "docs/01-app/02-guides/upgrading/version-15.mdx",
+        "docs/02-pages/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-router.mdx",
+        "docs/02-pages/04-api-reference/03-functions/use-search-params.mdx",
+        "docs/02-pages/03-building-your-application/01-routing/03-linking-and-navigating.mdx",
+        "docs/02-pages/03-building-your-application/01-routing/index.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find migration guide",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "app-router-migration.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 829.33,
+      "query": "upgrading from pages router to app router",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/02-guides/migrating/app-router-migration.mdx",
+        "docs/02-pages/02-guides/migrating/app-router-migration.mdx",
+        "docs/01-app/02-guides/upgrading/version-14.mdx",
+        "docs/01-app/02-guides/upgrading/version-16.mdx",
+        "docs/02-pages/02-guides/upgrading/version-14.mdx",
+        "docs/01-app/02-guides/upgrading/version-15.mdx",
+        "docs/02-pages/02-guides/upgrading/codemods.mdx",
+        "docs/01-app/02-guides/static-exports.mdx",
+        "docs/02-pages/02-guides/static-exports.mdx",
+        "docs/01-app/index.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find migration guide",
+      "engine": "codegraph",
+      "expected_files": [
+        "app-router-migration.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "upgrading from pages router to app router",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "full",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find CSP documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "content-security-policy.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 30.28,
+      "query": "security headers content security policy",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/02-guides/content-security-policy.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/headers.mdx",
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/02-guides/data-security.mdx",
+        "docs/01-app/02-guides/progressive-web-apps.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/02-pages/02-guides/content-security-policy.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/02-pages/04-api-reference/01-components/image-legacy.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find CSP documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "content-security-policy.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 795.61,
+      "query": "security headers content security policy",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/03-api-reference/02-components/image.mdx",
+        "docs/01-app/02-guides/content-security-policy.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/headers.mdx",
+        "docs/02-pages/02-guides/content-security-policy.mdx",
+        "docs/01-app/02-guides/progressive-web-apps.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/02-guides/data-security.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/proxy.mdx",
+        "packages/next/tsconfig.json",
+        "docs/01-app/03-api-reference/04-functions/headers.mdx"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find CSP documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "content-security-policy.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "security headers content security policy",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "full",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Natural language query about pre-rendering",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx",
+        "static-exports.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 31.28,
+      "query": "how does Next.js decide which pages to pre-render during build",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/layout.mdx",
+        "docs/02-pages/03-building-your-application/02-rendering/index.mdx",
+        "docs/02-pages/03-building-your-application/02-rendering/04-automatic-static-optimization.mdx",
+        "docs/01-app/01-getting-started/04-linking-and-navigating.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/exportPathMap.mdx",
+        "docs/01-app/02-guides/prefetching.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "packages/next/src/client/app-bootstrap.ts",
+        "docs/01-app/02-guides/single-page-applications.mdx",
+        "docs/01-app/03-api-reference/04-functions/use-search-params.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Natural language query about pre-rendering",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx",
+        "static-exports.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 880.47,
+      "query": "how does Next.js decide which pages to pre-render during build",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/02-pages/03-building-your-application/02-rendering/index.mdx",
+        "docs/02-pages/02-guides/draft-mode.mdx",
+        "docs/01-app/02-guides/production-checklist.mdx",
+        "docs/01-app/02-guides/single-page-applications.mdx",
+        "docs/02-pages/03-building-your-application/03-data-fetching/index.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/exportPathMap.mdx",
+        "docs/02-pages/04-api-reference/03-functions/get-static-paths.mdx",
+        "docs/02-pages/03-building-your-application/02-rendering/05-client-side-rendering.mdx",
+        "docs/01-app/03-api-reference/03-file-conventions/parallel-routes.mdx",
+        "docs/01-app/02-guides/upgrading/version-16.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Natural language query about pre-rendering",
+      "engine": "codegraph",
+      "expected_files": [
+        "static-generation-bailout.ts",
+        "is-static-gen-enabled.ts",
+        "static-site-generation.mdx",
+        "static-exports.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "how does Next.js decide which pages to pre-render during build",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "full",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Misspelled middleware query",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 26.44,
+      "query": "middlewear route matchng",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/shared/lib/router/router.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts",
+        "packages/next/src/experimental/testing/server/config-testing-utils.ts",
+        "docs/01-app/01-getting-started/02-project-structure.mdx",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.ts",
+        "docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx",
+        "packages/next/src/shared/lib/router/utils/sortable-routes.ts",
+        "packages/next/src/shared/lib/router/utils/route-regex.ts",
+        "packages/next/src/server/get-route-from-entrypoint.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Misspelled middleware query",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": 901.53,
+      "query": "middlewear route matchng",
+      "rank": 4,
+      "reciprocal_rank": 0.25,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.ts",
+        "packages/next/src/server/route-matchers/app-page-route-matcher.ts",
+        "packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts",
+        "packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts",
+        "packages/next/src/export/helpers/get-params.ts",
+        "packages/next/src/experimental/testing/server/middleware-testing-utils.test.ts",
+        "packages/next/src/shared/lib/router/utils/route-matcher.ts",
+        "packages/next/src/shared/lib/router/utils/interpolate-as.ts",
+        "packages/next/src/shared/lib/router/utils/prepare-destination.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Misspelled middleware query",
+      "engine": "codegraph",
+      "expected_files": [
+        "middleware-route-matcher.ts",
+        "middleware-config.ts"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "middlewear route matchng",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "full",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Multi-hop: image \u2192 optimizer \u2192 cache",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "image-optimizer.ts",
+        "incremental-cache",
+        "incrementalCacheHandlerPath.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 31.64,
+      "query": "the cache handler used by the image optimization API",
+      "rank": 5,
+      "reciprocal_rank": 0.2,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "packages/next/src/client/request/search-params.browser.dev.ts",
+        "docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx",
+        "packages/next/src/client/request/search-params.browser.prod.ts",
+        "packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts",
+        "packages/next/src/server/lib/incremental-cache/memory-cache.external.ts",
+        "packages/next/package.json",
+        "package.json",
+        "docs/01-app/02-guides/caching.mdx",
+        "packages/next/src/server/request/search-params.ts",
+        "packages/next/src/server/resume-data-cache/resume-data-cache.ts"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Multi-hop: image \u2192 optimizer \u2192 cache",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "image-optimizer.ts",
+        "incremental-cache",
+        "incrementalCacheHandlerPath.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": 782.49,
+      "query": "the cache handler used by the image optimization API",
+      "rank": 7,
+      "reciprocal_rank": 0.1429,
+      "repository": "nextjs",
+      "supported": true,
+      "tier": "full",
+      "top_files": [
+        "docs/02-pages/04-api-reference/01-components/image-legacy.mdx",
+        "docs/01-app/01-getting-started/12-images.mdx",
+        "docs/02-pages/01-getting-started/04-images.mdx",
+        "docs/01-app/02-guides/caching.mdx",
+        "docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx",
+        "docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx",
+        "packages/next/src/server/lib/incremental-cache/memory-cache.external.ts",
+        "docs/01-app/03-api-reference/04-functions/unstable_cache.mdx",
+        "packages/next/src/server/lib/incremental-cache/index.ts",
+        "docs/01-app/03-api-reference/01-directives/use-cache-private.mdx"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Multi-hop: image \u2192 optimizer \u2192 cache",
+      "engine": "codegraph",
+      "expected_files": [
+        "image-optimizer.ts",
+        "incremental-cache",
+        "incrementalCacheHandlerPath.mdx"
+      ],
+      "language": "typescript",
+      "latency_ms": null,
+      "query": "the cache handler used by the image optimization API",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "nextjs",
+      "supported": false,
+      "tier": "full",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "code",
+      "description": "Find request dispatch implementation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 108.68,
+      "query": "request dispatch and view function invocation",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "tests/test_async.py",
+        "tests/test_basic.py",
+        "src/flask/views.py",
+        "tests/test_views.py",
+        "src/flask/ctx.py",
+        "examples/tutorial/tests/test_blog.py",
+        "tests/test_reqctx.py",
+        "src/flask/wrappers.py",
+        "tests/type_check/typing_route.py",
+        "tests/test_helpers.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find request dispatch implementation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 575.64,
+      "query": "request dispatch and view function invocation",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/views.py",
+        "tests/test_views.py",
+        "tests/test_basic.py",
+        "tests/test_async.py",
+        "src/flask/ctx.py",
+        "src/flask/wrappers.py",
+        "src/flask/helpers.py",
+        "tests/test_blueprints.py",
+        "tests/test_templating.py",
+        "examples/celery/src/task_app/views.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find request dispatch implementation",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 591.48,
+      "query": "request dispatch and view function invocation",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/views.py",
+        "src/flask/app.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find secure cookie sessions",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/sessions.py"
+      ],
+      "language": "python",
+      "latency_ms": 15.86,
+      "query": "secure cookie session loading and saving",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/sessions.py",
+        "tests/test_reqctx.py",
+        "tests/test_basic.py",
+        "tests/test_testing.py",
+        "tests/test_session_interface.py",
+        "examples/tutorial/tests/test_blog.py",
+        "src/flask/testing.py",
+        "examples/tutorial/tests/test_auth.py",
+        "tests/test_converters.py",
+        "src/flask/json/tag.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find secure cookie sessions",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/sessions.py"
+      ],
+      "language": "python",
+      "latency_ms": 420.69,
+      "query": "secure cookie session loading and saving",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/sessions.py",
+        "tests/test_basic.py",
+        "tests/test_reqctx.py",
+        "src/flask/json/tag.py",
+        "tests/test_testing.py",
+        "tests/test_session_interface.py",
+        "examples/tutorial/flaskr/auth.py",
+        "src/flask/wrappers.py",
+        "src/flask/cli.py",
+        "tests/test_config.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find secure cookie sessions",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/sessions.py"
+      ],
+      "language": "python",
+      "latency_ms": 462.97,
+      "query": "secure cookie session loading and saving",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/sessions.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find template rendering",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/templating.py"
+      ],
+      "language": "python",
+      "latency_ms": 23.7,
+      "query": "render a Jinja template with context processors",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/templating.py",
+        "examples/javascript/tests/test_js_example.py",
+        "tests/test_blueprints.py",
+        "tests/test_signals.py",
+        "tests/test_templating.py",
+        "tests/type_check/typing_route.py",
+        "src/flask/app.py",
+        "examples/javascript/js_example/views.py",
+        "examples/tutorial/flaskr/blog.py",
+        "tests/test_json.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find template rendering",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/templating.py"
+      ],
+      "language": "python",
+      "latency_ms": 608.18,
+      "query": "render a Jinja template with context processors",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/templating.py",
+        "tests/test_json.py",
+        "tests/test_templating.py",
+        "tests/test_blueprints.py",
+        "tests/test_signals.py",
+        "src/flask/sansio/scaffold.py",
+        "src/flask/helpers.py",
+        "tests/test_apps/blueprintapp/apps/admin/__init__.py",
+        "tests/test_apps/blueprintapp/apps/frontend/__init__.py",
+        "examples/javascript/js_example/views.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find template rendering",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/templating.py"
+      ],
+      "language": "python",
+      "latency_ms": 464.82,
+      "query": "render a Jinja template with context processors",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/signals.py",
+        "src/flask/templating.py",
+        "src/flask/sansio/scaffold.py",
+        "src/flask/sansio/app.py"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find blueprint documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/blueprints.rst"
+      ],
+      "language": "python",
+      "latency_ms": 16.17,
+      "query": "organize a Flask application with blueprints",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/tutorial/views.rst",
+        "docs/blueprints.rst",
+        "pyproject.toml",
+        "CHANGES.rst",
+        "docs/views.rst",
+        "docs/tutorial/next.rst",
+        "docs/patterns/urlprocessors.rst",
+        "docs/tutorial/blog.rst",
+        "README.md",
+        "docs/patterns/appdispatch.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find blueprint documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/blueprints.rst"
+      ],
+      "language": "python",
+      "latency_ms": 712.84,
+      "query": "organize a Flask application with blueprints",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/tutorial/views.rst",
+        "docs/blueprints.rst",
+        "CHANGES.rst",
+        "docs/appcontext.rst",
+        "docs/index.rst",
+        "docs/api.rst",
+        "docs/patterns/urlprocessors.rst",
+        "docs/cli.rst",
+        "docs/quickstart.rst",
+        "README.md"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find blueprint documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/blueprints.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "organize a Flask application with blueprints",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find application factory guide",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/patterns/appfactories.rst"
+      ],
+      "language": "python",
+      "latency_ms": 15.87,
+      "query": "create and configure an application factory",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/testing.rst",
+        "docs/patterns/appfactories.rst",
+        "docs/cli.rst",
+        "docs/patterns/appdispatch.rst",
+        "docs/patterns/sqlalchemy.rst",
+        "docs/patterns/sqlite3.rst",
+        "docs/config.rst",
+        "docs/patterns/viewdecorators.rst",
+        "pyproject.toml",
+        "docs/tutorial/tests.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find application factory guide",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/patterns/appfactories.rst"
+      ],
+      "language": "python",
+      "latency_ms": 660.19,
+      "query": "create and configure an application factory",
+      "rank": 5,
+      "reciprocal_rank": 0.2,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/testing.rst",
+        "docs/tutorial/factory.rst",
+        "docs/patterns/celery.rst",
+        "docs/deploying/uwsgi.rst",
+        "docs/patterns/appfactories.rst",
+        "docs/tutorial/tests.rst",
+        "docs/cli.rst",
+        "docs/api.rst",
+        "docs/design.rst",
+        "docs/appcontext.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find application factory guide",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/patterns/appfactories.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "create and configure an application factory",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find error handling code or guide",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/app.py",
+        "docs/errorhandling.rst"
+      ],
+      "language": "python",
+      "latency_ms": 21.17,
+      "query": "how Flask handles exceptions and registered error handlers",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/flask/app.py",
+        "docs/errorhandling.rst",
+        "docs/lifecycle.rst",
+        "tests/test_basic.py",
+        "docs/reqcontext.rst",
+        "tests/test_appctx.py",
+        "tests/type_check/typing_error_handler.py",
+        "src/flask/wrappers.py",
+        "docs/blueprints.rst",
+        "CHANGES.rst"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find error handling code or guide",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/app.py",
+        "docs/errorhandling.rst"
+      ],
+      "language": "python",
+      "latency_ms": 816.16,
+      "query": "how Flask handles exceptions and registered error handlers",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/errorhandling.rst",
+        "docs/blueprints.rst",
+        "tests/test_user_error_handler.py",
+        "docs/api.rst",
+        "tests/test_blueprints.py",
+        "tests/type_check/typing_error_handler.py",
+        "docs/config.rst",
+        "tests/test_signals.py",
+        "docs/lifecycle.rst",
+        "tests/test_appctx.py"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find error handling code or guide",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/app.py",
+        "docs/errorhandling.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "how Flask handles exceptions and registered error handlers",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "cross",
+      "description": "Find context lifecycle code or docs",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/ctx.py",
+        "docs/reqcontext.rst",
+        "docs/appcontext.rst"
+      ],
+      "language": "python",
+      "latency_ms": 14.63,
+      "query": "application and request context push pop lifecycle",
+      "rank": 4,
+      "reciprocal_rank": 0.25,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "tests/test_testing.py",
+        "tests/test_reqctx.py",
+        "tests/test_signals.py",
+        "docs/reqcontext.rst",
+        "tests/test_basic.py",
+        "src/flask/ctx.py",
+        "docs/shell.rst",
+        "docs/lifecycle.rst",
+        "docs/appcontext.rst",
+        "docs/extensiondev.rst"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find context lifecycle code or docs",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/ctx.py",
+        "docs/reqcontext.rst",
+        "docs/appcontext.rst"
+      ],
+      "language": "python",
+      "latency_ms": 813.08,
+      "query": "application and request context push pop lifecycle",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/appcontext.rst",
+        "src/flask/ctx.py",
+        "tests/test_signals.py",
+        "docs/shell.rst",
+        "tests/test_testing.py",
+        "tests/test_reqctx.py",
+        "docs/api.rst",
+        "CHANGES.rst",
+        "docs/testing.rst",
+        "docs/reqcontext.rst"
+      ]
+    },
+    {
+      "category": "cross",
+      "description": "Find context lifecycle code or docs",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/ctx.py",
+        "docs/reqcontext.rst",
+        "docs/appcontext.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "application and request context push pop lifecycle",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "quick",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "code",
+      "description": "Find response conversion",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 19.08,
+      "query": "convert a view return value into a response object",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/helpers.py",
+        "src/flask/json/__init__.py",
+        "tests/test_views.py",
+        "tests/test_async.py",
+        "tests/test_basic.py",
+        "src/flask/ctx.py",
+        "src/flask/wrappers.py",
+        "tests/type_check/typing_route.py",
+        "src/flask/app.py",
+        "src/flask/typing.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find response conversion",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 648.27,
+      "query": "convert a view return value into a response object",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/helpers.py",
+        "src/flask/ctx.py",
+        "src/flask/json/__init__.py",
+        "src/flask/templating.py",
+        "src/flask/wrappers.py",
+        "tests/test_converters.py",
+        "src/flask/sansio/scaffold.py",
+        "src/flask/typing.py",
+        "tests/test_views.py",
+        "src/flask/cli.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find response conversion",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 448.6,
+      "query": "convert a view return value into a response object",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/views.py",
+        "src/flask/json/provider.py",
+        "src/flask/cli.py",
+        "src/flask/wrappers.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find blueprint registration",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/sansio/blueprints.py",
+        "src/flask/blueprints.py"
+      ],
+      "language": "python",
+      "latency_ms": 15.51,
+      "query": "register a blueprint and deferred setup operations",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/sansio/blueprints.py",
+        "tests/test_blueprints.py",
+        "tests/test_cli.py",
+        "tests/test_basic.py",
+        "tests/test_testing.py",
+        "examples/celery/src/task_app/views.py",
+        "src/flask/debughelpers.py",
+        "tests/test_templating.py",
+        "src/flask/blueprints.py",
+        "examples/tutorial/flaskr/blog.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find blueprint registration",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/sansio/blueprints.py",
+        "src/flask/blueprints.py"
+      ],
+      "language": "python",
+      "latency_ms": 627.73,
+      "query": "register a blueprint and deferred setup operations",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/sansio/blueprints.py",
+        "tests/test_testing.py",
+        "tests/test_cli.py",
+        "tests/test_basic.py",
+        "tests/test_blueprints.py",
+        "tests/test_apps/blueprintapp/__init__.py",
+        "src/flask/blueprints.py",
+        "examples/celery/src/task_app/__init__.py",
+        "tests/test_async.py",
+        "src/flask/debughelpers.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find blueprint registration",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/sansio/blueprints.py",
+        "src/flask/blueprints.py"
+      ],
+      "language": "python",
+      "latency_ms": 480.77,
+      "query": "register a blueprint and deferred setup operations",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/sansio/blueprints.py",
+        "src/flask/sansio/app.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find URL generation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 15.54,
+      "query": "generate URLs inside and outside a request context",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/helpers.py",
+        "tests/test_appctx.py",
+        "tests/test_basic.py",
+        "src/flask/ctx.py",
+        "tests/test_reqctx.py",
+        "tests/test_testing.py",
+        "tests/test_helpers.py",
+        "src/flask/app.py",
+        "src/flask/templating.py",
+        "tests/type_check/typing_route.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find URL generation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 457.64,
+      "query": "generate URLs inside and outside a request context",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/helpers.py",
+        "src/flask/ctx.py",
+        "tests/test_reqctx.py",
+        "tests/test_testing.py",
+        "src/flask/templating.py",
+        "src/flask/wrappers.py",
+        "src/flask/globals.py",
+        "tests/test_appctx.py",
+        "tests/test_converters.py",
+        "tests/type_check/typing_route.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find URL generation",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/app.py",
+        "src/flask/helpers.py"
+      ],
+      "language": "python",
+      "latency_ms": 480.5,
+      "query": "generate URLs inside and outside a request context",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/app.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find MethodView dispatch",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/views.py"
+      ],
+      "language": "python",
+      "latency_ms": 23.12,
+      "query": "class based views dispatch HTTP methods",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/views.py",
+        "tests/test_async.py",
+        "tests/test_views.py",
+        "tests/test_basic.py",
+        "src/flask/wrappers.py",
+        "src/flask/app.py",
+        "tests/test_helpers.py",
+        "tests/type_check/typing_route.py",
+        "tests/test_appctx.py",
+        "src/flask/ctx.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find MethodView dispatch",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/views.py"
+      ],
+      "language": "python",
+      "latency_ms": 476.61,
+      "query": "class based views dispatch HTTP methods",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "tests/test_views.py",
+        "src/flask/views.py",
+        "tests/test_async.py",
+        "tests/test_basic.py",
+        "src/flask/wrappers.py",
+        "src/flask/templating.py",
+        "tests/test_helpers.py",
+        "tests/test_user_error_handler.py",
+        "src/flask/debughelpers.py",
+        "tests/type_check/typing_route.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find MethodView dispatch",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/views.py"
+      ],
+      "language": "python",
+      "latency_ms": 460.41,
+      "query": "class based views dispatch HTTP methods",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/views.py",
+        "src/flask/app.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find CLI application discovery",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/cli.py"
+      ],
+      "language": "python",
+      "latency_ms": 53.35,
+      "query": "discover and load an application for the flask command",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "tests/test_cli.py",
+        "src/flask/cli.py",
+        "tests/test_apps/cliapp/app.py",
+        "tests/test_apps/cliapp/inner1/inner2/flask.py",
+        "tests/test_apps/cliapp/inner1/__init__.py",
+        "tests/test_apps/cliapp/factory.py",
+        "src/flask/json/__init__.py",
+        "tests/test_signals.py",
+        "tests/test_regression.py",
+        "tests/test_templating.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find CLI application discovery",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/cli.py"
+      ],
+      "language": "python",
+      "latency_ms": 794.44,
+      "query": "discover and load an application for the flask command",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/testing.py",
+        "src/flask/json/__init__.py",
+        "examples/tutorial/flaskr/db.py",
+        "examples/tutorial/flaskr/__init__.py",
+        "src/flask/app.py",
+        "tests/test_cli.py",
+        "src/flask/sansio/app.py",
+        "examples/tutorial/tests/conftest.py",
+        "tests/test_json.py",
+        "examples/celery/src/task_app/__init__.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find CLI application discovery",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/cli.py"
+      ],
+      "language": "python",
+      "latency_ms": 473.61,
+      "query": "discover and load an application for the flask command",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/json/provider.py",
+        "src/flask/cli.py",
+        "src/flask/json/__init__.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find JSON provider",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/json/provider.py"
+      ],
+      "language": "python",
+      "latency_ms": 26.09,
+      "query": "serialize JSON responses with the default provider",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/json/provider.py",
+        "src/flask/json/__init__.py",
+        "tests/test_json.py",
+        "src/flask/sessions.py",
+        "tests/test_testing.py",
+        "src/flask/json/tag.py",
+        "tests/test_basic.py",
+        "tests/test_json_tag.py",
+        "examples/tutorial/tests/test_blog.py",
+        "src/flask/wrappers.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find JSON provider",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/json/provider.py"
+      ],
+      "language": "python",
+      "latency_ms": 542.69,
+      "query": "serialize JSON responses with the default provider",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/json/provider.py",
+        "src/flask/json/__init__.py",
+        "tests/test_json.py",
+        "src/flask/sessions.py",
+        "src/flask/json/tag.py",
+        "src/flask/wrappers.py",
+        "tests/test_testing.py",
+        "tests/test_basic.py",
+        "tests/test_json_tag.py",
+        "examples/javascript/js_example/views.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find JSON provider",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/json/provider.py"
+      ],
+      "language": "python",
+      "latency_ms": 480.1,
+      "query": "serialize JSON responses with the default provider",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/json/provider.py",
+        "src/flask/json/tag.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find request preprocessing",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 21.42,
+      "query": "run before request preprocessors in blueprint order",
+      "rank": 7,
+      "reciprocal_rank": 0.1429,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "tests/test_basic.py",
+        "tests/test_blueprints.py",
+        "tests/test_cli.py",
+        "examples/celery/src/task_app/views.py",
+        "src/flask/sansio/blueprints.py",
+        "src/flask/blueprints.py",
+        "src/flask/app.py",
+        "tests/test_testing.py",
+        "tests/test_async.py",
+        "examples/tutorial/flaskr/blog.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find request preprocessing",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 736.57,
+      "query": "run before request preprocessors in blueprint order",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "tests/test_blueprints.py",
+        "tests/test_async.py",
+        "src/flask/sansio/blueprints.py",
+        "tests/test_testing.py",
+        "examples/celery/src/task_app/views.py",
+        "src/flask/blueprints.py",
+        "tests/test_templating.py",
+        "examples/tutorial/flaskr/blog.py",
+        "src/flask/helpers.py",
+        "tests/test_basic.py"
+      ]
+    },
+    {
+      "category": "code",
+      "description": "Find request preprocessing",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/app.py"
+      ],
+      "language": "python",
+      "latency_ms": 469.93,
+      "query": "run before request preprocessors in blueprint order",
+      "rank": null,
+      "reciprocal_rank": 0.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "src/flask/wrappers.py",
+        "src/flask/sansio/scaffold.py"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find request lifecycle guide",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/lifecycle.rst"
+      ],
+      "language": "python",
+      "latency_ms": 18.21,
+      "query": "complete request handling lifecycle step by step",
+      "rank": 3,
+      "reciprocal_rank": 0.3333,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/views.rst",
+        "docs/testing.rst",
+        "docs/lifecycle.rst",
+        "docs/patterns/sqlalchemy.rst",
+        "docs/patterns/viewdecorators.rst",
+        "docs/patterns/javascript.rst",
+        "CHANGES.rst",
+        "docs/patterns/appdispatch.rst",
+        "docs/patterns/sqlite3.rst",
+        "docs/tutorial/views.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find request lifecycle guide",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/lifecycle.rst"
+      ],
+      "language": "python",
+      "latency_ms": 751.23,
+      "query": "complete request handling lifecycle step by step",
+      "rank": 8,
+      "reciprocal_rank": 0.125,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/reqcontext.rst",
+        "docs/patterns/deferredcallbacks.rst",
+        "docs/api.rst",
+        "docs/blueprints.rst",
+        "docs/index.rst",
+        "docs/patterns/sqlite3.rst",
+        "docs/web-security.rst",
+        "docs/lifecycle.rst",
+        "docs/testing.rst",
+        "docs/quickstart.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find request lifecycle guide",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/lifecycle.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "complete request handling lifecycle step by step",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find web security guidance",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/web-security.rst"
+      ],
+      "language": "python",
+      "latency_ms": 17.64,
+      "query": "security headers content security policy and cookie settings",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/web-security.rst",
+        "docs/config.rst",
+        "CHANGES.rst",
+        "docs/tutorial/views.rst",
+        "docs/quickstart.rst",
+        "tests/static/config.json",
+        "docs/tutorial/templates.rst",
+        "tests/templates/non_escaping_template.txt",
+        "tests/templates/escaping_template.html",
+        "examples/tutorial/flaskr/templates/auth/login.html"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find web security guidance",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/web-security.rst"
+      ],
+      "language": "python",
+      "latency_ms": 707.94,
+      "query": "security headers content security policy and cookie settings",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/web-security.rst",
+        "docs/config.rst",
+        "docs/quickstart.rst",
+        "docs/tutorial/templates.rst",
+        "examples/tutorial/flaskr/templates/auth/register.html",
+        "CHANGES.rst",
+        "examples/tutorial/flaskr/templates/auth/login.html",
+        "examples/tutorial/flaskr/templates/blog/create.html",
+        "docs/tutorial/deploy.rst",
+        "examples/tutorial/flaskr/templates/blog/update.html"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find web security guidance",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/web-security.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "security headers content security policy and cookie settings",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find async view documentation",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/async-await.rst"
+      ],
+      "language": "python",
+      "latency_ms": 19.19,
+      "query": "use async await in route views",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/async-await.rst",
+        "docs/patterns/javascript.rst",
+        "docs/views.rst",
+        "docs/api.rst",
+        "docs/patterns/celery.rst",
+        "docs/lifecycle.rst",
+        "CHANGES.rst",
+        "docs/patterns/viewdecorators.rst",
+        "docs/tutorial/views.rst",
+        "docs/testing.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find async view documentation",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/async-await.rst"
+      ],
+      "language": "python",
+      "latency_ms": 651.72,
+      "query": "use async await in route views",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/async-await.rst",
+        "docs/deploying/eventlet.rst",
+        "docs/deploying/gunicorn.rst",
+        "docs/design.rst",
+        "CHANGES.rst",
+        "docs/deploying/gevent.rst",
+        "docs/deploying/asgi.rst",
+        "docs/patterns/lazyloading.rst",
+        "docs/quickstart.rst",
+        "docs/patterns/celery.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find async view documentation",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/async-await.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "use async await in route views",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find testing guide",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/testing.rst"
+      ],
+      "language": "python",
+      "latency_ms": 18.29,
+      "query": "test an application with pytest fixtures and the test client",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/testing.rst",
+        "docs/tutorial/tests.rst",
+        "CHANGES.rst",
+        "pyproject.toml",
+        "examples/tutorial/README.rst",
+        "docs/quickstart.rst",
+        "examples/javascript/README.rst",
+        "examples/tutorial/pyproject.toml"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find testing guide",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/testing.rst"
+      ],
+      "language": "python",
+      "latency_ms": 186.68,
+      "query": "test an application with pytest fixtures and the test client",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/testing.rst",
+        "docs/tutorial/tests.rst",
+        "examples/tutorial/README.rst",
+        "CHANGES.rst",
+        "examples/javascript/README.rst",
+        "examples/tutorial/pyproject.toml",
+        "pyproject.toml",
+        "docs/quickstart.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find testing guide",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/testing.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "test an application with pytest fixtures and the test client",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find streaming pattern",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "docs/patterns/streaming.rst"
+      ],
+      "language": "python",
+      "latency_ms": 18.89,
+      "query": "stream a response from a generator while keeping request context",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/patterns/streaming.rst",
+        "CHANGES.rst",
+        "docs/lifecycle.rst",
+        "docs/testing.rst",
+        "docs/reqcontext.rst",
+        "docs/quickstart.rst",
+        "docs/patterns/javascript.rst",
+        "docs/patterns/requestchecksum.rst",
+        "docs/shell.rst",
+        "docs/views.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find streaming pattern",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "docs/patterns/streaming.rst"
+      ],
+      "language": "python",
+      "latency_ms": 582.54,
+      "query": "stream a response from a generator while keeping request context",
+      "rank": 1,
+      "reciprocal_rank": 1.0,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/patterns/streaming.rst",
+        "CHANGES.rst",
+        "docs/shell.rst",
+        "docs/lifecycle.rst",
+        "docs/api.rst",
+        "docs/appcontext.rst",
+        "docs/patterns/requestchecksum.rst",
+        "docs/reqcontext.rst",
+        "docs/quickstart.rst",
+        "docs/extensiondev.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find streaming pattern",
+      "engine": "codegraph",
+      "expected_files": [
+        "docs/patterns/streaming.rst"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "stream a response from a generator while keeping request context",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    },
+    {
+      "category": "document",
+      "description": "Find Sans-IO Markdown architecture note",
+      "engine": "tessera_bge_small",
+      "expected_files": [
+        "src/flask/sansio/README.md"
+      ],
+      "language": "python",
+      "latency_ms": 15.49,
+      "query": "sans io base classes separate framework logic from the web server",
+      "rank": 10,
+      "reciprocal_rank": 0.1,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "docs/web-security.rst",
+        "tests/static/config.json",
+        "CHANGES.rst",
+        "pyproject.toml",
+        "docs/index.rst",
+        "docs/design.rst",
+        "examples/javascript/js_example/templates/fetch.html",
+        "docs/quickstart.rst",
+        "docs/patterns/sqlalchemy.rst",
+        "src/flask/sansio/README.md"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find Sans-IO Markdown architecture note",
+      "engine": "tessera_bge_small_jina_tiny",
+      "expected_files": [
+        "src/flask/sansio/README.md"
+      ],
+      "language": "python",
+      "latency_ms": 651.4,
+      "query": "sans io base classes separate framework logic from the web server",
+      "rank": 2,
+      "reciprocal_rank": 0.5,
+      "repository": "flask",
+      "supported": true,
+      "tier": "standard",
+      "top_files": [
+        "CHANGES.rst",
+        "src/flask/sansio/README.md",
+        "README.md",
+        "docs/index.rst",
+        "pyproject.toml",
+        "docs/design.rst",
+        "docs/config.rst",
+        "docs/deploying/index.rst",
+        "docs/tutorial/templates.rst",
+        "docs/tutorial/static.rst"
+      ]
+    },
+    {
+      "category": "document",
+      "description": "Find Sans-IO Markdown architecture note",
+      "engine": "codegraph",
+      "expected_files": [
+        "src/flask/sansio/README.md"
+      ],
+      "language": "python",
+      "latency_ms": null,
+      "query": "sans io base classes separate framework logic from the web server",
+      "rank": null,
+      "reciprocal_rank": null,
+      "repository": "flask",
+      "supported": false,
+      "tier": "standard",
+      "top_files": [],
+      "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content"
+    }
+  ],
+  "repositories": {
+    "flask": {
+      "codegraph_index": {
+        "cached": true,
+        "setup_ms": 0.0
+      },
+      "configured_ref": "3.1.2",
+      "languages": [
+        "python"
+      ],
+      "revision": "2c1b30d0503cfb064f1cb252e6614a06915a362a"
+    },
+    "nextjs": {
+      "codegraph_index": {
+        "cached": true,
+        "setup_ms": 0.0
+      },
+      "configured_ref": "v16.1.6",
+      "languages": [
+        "typescript",
+        "javascript"
+      ],
+      "revision": "adf8c612adddd103647c90ff0f511ea35c57076e"
+    }
+  },
+  "summary": {
+    "comparable_code": {
+      "codegraph": {
+        "latency_ms_mean": 2931.09,
+        "latency_ms_p50": 4411.46,
+        "latency_ms_p95": 5550.22,
+        "mrr_at_10": 0.413,
+        "queries_supported": 23,
+        "queries_total": 23,
+        "queries_unsupported": 0,
+        "top_1": 0.3478,
+        "top_10": 0.4783,
+        "top_3": 0.4783,
+        "top_5": 0.4783
+      },
+      "tessera_bge_small": {
+        "latency_ms_mean": 49.51,
+        "latency_ms_p50": 33.26,
+        "latency_ms_p95": 120.09,
+        "mrr_at_10": 0.5062,
+        "queries_supported": 23,
+        "queries_total": 23,
+        "queries_unsupported": 0,
+        "top_1": 0.4348,
+        "top_10": 0.6087,
+        "top_3": 0.5652,
+        "top_5": 0.5652
+      },
+      "tessera_bge_small_jina_tiny": {
+        "latency_ms_mean": 768.77,
+        "latency_ms_p50": 799.73,
+        "latency_ms_p95": 1037.52,
+        "mrr_at_10": 0.5768,
+        "queries_supported": 23,
+        "queries_total": 23,
+        "queries_unsupported": 0,
+        "top_1": 0.4783,
+        "top_10": 0.7391,
+        "top_3": 0.6522,
+        "top_5": 0.6522
+      }
+    },
+    "overall": {
+      "codegraph": {
+        "latency_ms_mean": 2931.09,
+        "latency_ms_p50": 4411.46,
+        "latency_ms_p95": 5550.22,
+        "mrr_at_10": 0.413,
+        "queries_supported": 23,
+        "queries_total": 58,
+        "queries_unsupported": 35,
+        "top_1": 0.3478,
+        "top_10": 0.4783,
+        "top_3": 0.4783,
+        "top_5": 0.4783
+      },
+      "tessera_bge_small": {
+        "latency_ms_mean": 39.5,
+        "latency_ms_p50": 29.46,
+        "latency_ms_p95": 95.09,
+        "mrr_at_10": 0.6102,
+        "queries_supported": 58,
+        "queries_total": 58,
+        "queries_unsupported": 0,
+        "top_1": 0.5,
+        "top_10": 0.8103,
+        "top_3": 0.6724,
+        "top_5": 0.7586
+      },
+      "tessera_bge_small_jina_tiny": {
+        "latency_ms_mean": 787.61,
+        "latency_ms_p50": 811.87,
+        "latency_ms_p95": 969.78,
+        "mrr_at_10": 0.5876,
+        "queries_supported": 58,
+        "queries_total": 58,
+        "queries_unsupported": 0,
+        "top_1": 0.4655,
+        "top_10": 0.8276,
+        "top_3": 0.6552,
+        "top_5": 0.7414
+      }
+    },
+    "ranker_routing": {
+      "categories": {
+        "code": {
+          "latency_ms_mean": 768.77,
+          "latency_ms_p50": 799.73,
+          "latency_ms_p95": 1037.52,
+          "mrr_at_10": 0.5768,
+          "queries_supported": 23,
+          "queries_total": 23,
+          "queries_unsupported": 0,
+          "top_1": 0.4783,
+          "top_10": 0.7391,
+          "top_3": 0.6522,
+          "top_5": 0.6522
+        },
+        "cross": {
+          "latency_ms_mean": 32.44,
+          "latency_ms_p50": 28.79,
+          "latency_ms_p95": 50.65,
+          "mrr_at_10": 0.4885,
+          "queries_supported": 16,
+          "queries_total": 16,
+          "queries_unsupported": 0,
+          "top_1": 0.3125,
+          "top_10": 0.875,
+          "top_3": 0.5,
+          "top_5": 0.8125
+        },
+        "document": {
+          "latency_ms_mean": 33.32,
+          "latency_ms_p50": 28.88,
+          "latency_ms_p95": 81.32,
+          "mrr_at_10": 0.8386,
+          "queries_supported": 19,
+          "queries_total": 19,
+          "queries_unsupported": 0,
+          "top_1": 0.7368,
+          "top_10": 1.0,
+          "top_3": 0.9474,
+          "top_5": 0.9474
+        }
+      },
+      "overall": {
+        "latency_ms_mean": 324.72,
+        "latency_ms_p50": 36.38,
+        "latency_ms_p95": 964.41,
+        "mrr_at_10": 0.6382,
+        "queries_supported": 58,
+        "queries_total": 58,
+        "queries_unsupported": 0,
+        "top_1": 0.5172,
+        "top_10": 0.8621,
+        "top_3": 0.7069,
+        "top_5": 0.7931
+      },
+      "policy": "Jina-tiny reranking for code; base hybrid order for document and cross queries",
+      "post_hoc": true
+    },
+    "segments": {
+      "codegraph/flask/code": {
+        "latency_ms_mean": 481.32,
+        "latency_ms_p50": 471.77,
+        "latency_ms_p95": 541.66,
+        "mrr_at_10": 0.65,
+        "queries_supported": 10,
+        "queries_total": 10,
+        "queries_unsupported": 0,
+        "top_1": 0.5,
+        "top_10": 0.8,
+        "top_3": 0.8,
+        "top_5": 0.8
+      },
+      "codegraph/flask/cross": {
+        "latency_ms_mean": 0.0,
+        "latency_ms_p50": 0.0,
+        "latency_ms_p95": 0.0,
+        "mrr_at_10": 0.0,
+        "queries_supported": 0,
+        "queries_total": 2,
+        "queries_unsupported": 2,
+        "top_1": 0.0,
+        "top_10": 0.0,
+        "top_3": 0.0,
+        "top_5": 0.0
+      },
+      "codegraph/flask/document": {
+        "latency_ms_mean": 0.0,
+        "latency_ms_p50": 0.0,
+        "latency_ms_p95": 0.0,
+        "mrr_at_10": 0.0,
+        "queries_supported": 0,
+        "queries_total": 8,
+        "queries_unsupported": 8,
+        "top_1": 0.0,
+        "top_10": 0.0,
+        "top_3": 0.0,
+        "top_5": 0.0
+      },
+      "codegraph/nextjs/code": {
+        "latency_ms_mean": 4815.52,
+        "latency_ms_p50": 4549.72,
+        "latency_ms_p95": 5928.3,
+        "mrr_at_10": 0.2308,
+        "queries_supported": 13,
+        "queries_total": 13,
+        "queries_unsupported": 0,
+        "top_1": 0.2308,
+        "top_10": 0.2308,
+        "top_3": 0.2308,
+        "top_5": 0.2308
+      },
+      "codegraph/nextjs/cross": {
+        "latency_ms_mean": 0.0,
+        "latency_ms_p50": 0.0,
+        "latency_ms_p95": 0.0,
+        "mrr_at_10": 0.0,
+        "queries_supported": 0,
+        "queries_total": 14,
+        "queries_unsupported": 14,
+        "top_1": 0.0,
+        "top_10": 0.0,
+        "top_3": 0.0,
+        "top_5": 0.0
+      },
+      "codegraph/nextjs/document": {
+        "latency_ms_mean": 0.0,
+        "latency_ms_p50": 0.0,
+        "latency_ms_p95": 0.0,
+        "mrr_at_10": 0.0,
+        "queries_supported": 0,
+        "queries_total": 11,
+        "queries_unsupported": 11,
+        "top_1": 0.0,
+        "top_10": 0.0,
+        "top_3": 0.0,
+        "top_5": 0.0
+      },
+      "tessera_bge_small/flask/code": {
+        "latency_ms_mean": 32.23,
+        "latency_ms_p50": 22.27,
+        "latency_ms_p95": 83.78,
+        "mrr_at_10": 0.7643,
+        "queries_supported": 10,
+        "queries_total": 10,
+        "queries_unsupported": 0,
+        "top_1": 0.7,
+        "top_10": 0.9,
+        "top_3": 0.8,
+        "top_5": 0.8
+      },
+      "tessera_bge_small/flask/cross": {
+        "latency_ms_mean": 17.9,
+        "latency_ms_p50": 17.9,
+        "latency_ms_p95": 20.84,
+        "mrr_at_10": 0.625,
+        "queries_supported": 2,
+        "queries_total": 2,
+        "queries_unsupported": 0,
+        "top_1": 0.5,
+        "top_10": 1.0,
+        "top_3": 0.5,
+        "top_5": 1.0
+      },
+      "tessera_bge_small/flask/document": {
+        "latency_ms_mean": 17.47,
+        "latency_ms_p50": 17.93,
+        "latency_ms_p95": 19.09,
+        "mrr_at_10": 0.6792,
+        "queries_supported": 8,
+        "queries_total": 8,
+        "queries_unsupported": 0,
+        "top_1": 0.5,
+        "top_10": 1.0,
+        "top_3": 0.875,
+        "top_5": 0.875
+      },
+      "tessera_bge_small/nextjs/code": {
+        "latency_ms_mean": 62.8,
+        "latency_ms_p50": 37.41,
+        "latency_ms_p95": 135.37,
+        "mrr_at_10": 0.3077,
+        "queries_supported": 13,
+        "queries_total": 13,
+        "queries_unsupported": 0,
+        "top_1": 0.2308,
+        "top_10": 0.3846,
+        "top_3": 0.3846,
+        "top_5": 0.3846
+      },
+      "tessera_bge_small/nextjs/cross": {
+        "latency_ms_mean": 34.52,
+        "latency_ms_p50": 29.46,
+        "latency_ms_p95": 55.31,
+        "mrr_at_10": 0.469,
+        "queries_supported": 14,
+        "queries_total": 14,
+        "queries_unsupported": 0,
+        "top_1": 0.2857,
+        "top_10": 0.8571,
+        "top_3": 0.5,
+        "top_5": 0.7857
+      },
+      "tessera_bge_small/nextjs/document": {
+        "latency_ms_mean": 44.84,
+        "latency_ms_p50": 32.58,
+        "latency_ms_p95": 83.37,
+        "mrr_at_10": 0.9545,
+        "queries_supported": 11,
+        "queries_total": 11,
+        "queries_unsupported": 0,
+        "top_1": 0.9091,
+        "top_10": 1.0,
+        "top_3": 1.0,
+        "top_5": 1.0
+      },
+      "tessera_bge_small_jina_tiny/flask/code": {
+        "latency_ms_mean": 588.85,
+        "latency_ms_p50": 591.91,
+        "latency_ms_p95": 768.4,
+        "mrr_at_10": 0.65,
+        "queries_supported": 10,
+        "queries_total": 10,
+        "queries_unsupported": 0,
+        "top_1": 0.6,
+        "top_10": 0.7,
+        "top_3": 0.7,
+        "top_5": 0.7
+      },
+      "tessera_bge_small_jina_tiny/flask/cross": {
+        "latency_ms_mean": 814.62,
+        "latency_ms_p50": 814.62,
+        "latency_ms_p95": 816.01,
+        "mrr_at_10": 1.0,
+        "queries_supported": 2,
+        "queries_total": 2,
+        "queries_unsupported": 0,
+        "top_1": 1.0,
+        "top_10": 1.0,
+        "top_3": 1.0,
+        "top_5": 1.0
+      },
+      "tessera_bge_small_jina_tiny/flask/document": {
+        "latency_ms_mean": 613.07,
+        "latency_ms_p50": 655.96,
+        "latency_ms_p95": 737.79,
+        "mrr_at_10": 0.6656,
+        "queries_supported": 8,
+        "queries_total": 8,
+        "queries_unsupported": 0,
+        "top_1": 0.5,
+        "top_10": 1.0,
+        "top_3": 0.75,
+        "top_5": 0.875
+      },
+      "tessera_bge_small_jina_tiny/nextjs/code": {
+        "latency_ms_mean": 907.17,
+        "latency_ms_p50": 872.54,
+        "latency_ms_p95": 1104.52,
+        "mrr_at_10": 0.5205,
+        "queries_supported": 13,
+        "queries_total": 13,
+        "queries_unsupported": 0,
+        "top_1": 0.3846,
+        "top_10": 0.7692,
+        "top_3": 0.6154,
+        "top_5": 0.6154
+      },
+      "tessera_bge_small_jina_tiny/nextjs/cross": {
+        "latency_ms_mean": 872.87,
+        "latency_ms_p50": 877.02,
+        "latency_ms_p95": 966.2,
+        "mrr_at_10": 0.3697,
+        "queries_supported": 14,
+        "queries_total": 14,
+        "queries_unsupported": 0,
+        "top_1": 0.2143,
+        "top_10": 0.7143,
+        "top_3": 0.4286,
+        "top_5": 0.6429
+      },
+      "tessera_bge_small_jina_tiny/nextjs/document": {
+        "latency_ms_mean": 840.51,
+        "latency_ms_p50": 829.33,
+        "latency_ms_p95": 948.59,
+        "mrr_at_10": 0.7556,
+        "queries_supported": 11,
+        "queries_total": 11,
+        "queries_unsupported": 0,
+        "top_1": 0.6364,
+        "top_10": 1.0,
+        "top_3": 0.8182,
+        "top_5": 0.9091
+      }
+    }
+  }
+}

--- a/docs/benchmark-competitive-2026-07-14.md
+++ b/docs/benchmark-competitive-2026-07-14.md
@@ -6,7 +6,7 @@
 
 **Tessera leads the normalized source-code comparison on MRR@10.** Tessera with BGE-small + Jina-tiny scored 0.577; CodeGraph scored 0.413 across the same Python and TypeScript query set. Tessera also covers document and mixed-source queries, which CodeGraph does not index and which are therefore reported separately.
 
-Across all Tessera-supported content, reranking every query is counterproductive: base hybrid retrieval scored 0.610, global Jina-tiny reranking scored 0.588, and the post-hoc code-only reranking policy scored 0.638.
+Across all Tessera-supported content, reranking every query is counterproductive: base hybrid retrieval scored 0.610, global Jina-tiny reranking scored 0.588, and a post-hoc code-only oracle scored 0.638. The oracle was selected after inspecting these rows and is not a product policy or evidence for language/content routing.
 
 The exact-edge guardrail remains 4/4 for Tessera versus 3/4 for CodeGraph. These graph cases measure exact target correctness, not retrieval ranking.
 
@@ -24,7 +24,7 @@ Latency is directional: Tessera uses an in-process cached index, while CodeGraph
 
 ## Ranker Ablation Across All Content
 
-The routed policy is derived from the same measured rows: use Jina-tiny for code queries and preserve base hybrid ordering for document and mixed queries.
+The oracle is derived from the same measured rows: it selects Jina-tiny for code queries and preserves base hybrid ordering for document and mixed queries. It estimates possible headroom only; implementing it would overfit this benchmark.
 
 | Tessera policy | Queries | MRR@10 | Top-1 | Top-3 | Top-10 |
 |---|---:|---:|---:|---:|---:|
@@ -66,10 +66,11 @@ The Flask document subset improved from 0/2 to 2/2 Top-10 under both configurati
 
 ## Engineering Priorities
 
-1. **Gate reranking by content and language.** Jina-tiny improves Next.js code MRR from 0.308 to 0.520, but reduces Flask code from 0.764 to 0.650 and combined document retrieval from 0.839 to 0.718. Validate a TypeScript/code-only gate on an independent set before changing defaults.
-2. **Improve TypeScript candidate generation.** Even after reranking, Next.js code Top-10 is 77%; the remaining misses are webpack configuration, HMR, and static generation. These should become regression cases before tuning weights.
-3. **Sweep rankers behind the routed baseline.** Compare Jina tiny, turbo, and v3 (and code-specialized embedders such as CodeRankEmbed) per language/content segment rather than selecting on one aggregate.
-4. **Finish the broader benchmark program.** Expand the exact graph track beyond four collision cases, add independently authored relevance labels, and run process-normalized latency plus repeated agent-task evaluations.
+1. **Establish repository-level development and sealed-holdout sets.** This visible Flask/Next.js suite has already shaped hypotheses and is now regression/diagnostic evidence only. Do not choose routes, weights, constants, models, or query expansions from it.
+2. **Fix structural candidate limitations.** Validate a real two-stage candidate/rerank pool and first-class path and symbol candidate channels on different development repositories. The production code currently cannot rerank candidates it never retrieved, and post-merge metadata boosts cannot create missing candidates.
+3. **Improve representations without query-specific patches.** Test bounded AST splitting, hierarchical file-to-chunk retrieval, and separately searchable metadata views across multiple languages and repositories. Translate failures into general invariants rather than adding visible benchmark queries to product logic.
+4. **Defer model and routing selection.** Sweep rankers and code-specialized embedders only after candidate architecture is fixed. Promote nothing without repository-level development evidence and a single frozen milestone holdout.
+5. **Finish the broader benchmark program.** Expand the exact graph track beyond four collision cases, add independently authored relevance labels, and run process-normalized latency plus repeated agent-task evaluations.
 
 ## Method and Definitions
 
@@ -79,11 +80,11 @@ The Flask document subset improved from 0/2 to 2/2 Top-10 under both configurati
 - **Top-k:** fraction of supported queries with any expected file in the first k unique file results.
 - **Documents:** Markdown, MDX, and reStructuredText are grouped as document retrieval. Unsupported CodeGraph rows are excluded rather than scored as failures.
 - **Tessera configuration:** BGE-small embeddings, hybrid retrieval, file deduplication; one run without reranking and one with Jina-tiny reranking.
-- **Routing ablation:** post-hoc selection from measured rows, not a third model execution; it should be confirmed on an independent query set before becoming a default.
+- **Routing oracle:** post-hoc selection from measured rows, not a third model execution. It must not become a default or define a routing rule; future policies require repository-level development evidence and a sealed milestone holdout.
 - **CodeGraph adapter:** ordered source-code file blocks emitted by `codegraph explore --max-files 10`.
 
 ## Validation Assessment
 
 **Share with caveats.** File-level relevance labels and calculations are deterministic and machine-readable. The sample is broad enough to guide engineering priorities, but it is curated rather than independently blinded, and latency is not a process-normalized performance comparison.
 
-Recommended next step: inspect the per-query misses in the JSON artifact, then add the highest-impact failures as permanent regression cases before changing models or ranker weights.
+Recommended next step: classify misses into general failure modes, build independent synthetic invariants and different-repository development cases, then measure structural candidate improvements before changing models or ranker weights.

--- a/docs/benchmark-competitive-2026-07-14.md
+++ b/docs/benchmark-competitive-2026-07-14.md
@@ -1,0 +1,89 @@
+# Tessera vs CodeGraph: Python, TypeScript, and Documentation Benchmark
+
+*Generated 2026-07-14T05:10:25.144042+00:00 from pinned Flask and Next.js revisions.*
+
+## Technical Summary
+
+**Tessera leads the normalized source-code comparison on MRR@10.** Tessera with BGE-small + Jina-tiny scored 0.577; CodeGraph scored 0.413 across the same Python and TypeScript query set. Tessera also covers document and mixed-source queries, which CodeGraph does not index and which are therefore reported separately.
+
+Across all Tessera-supported content, reranking every query is counterproductive: base hybrid retrieval scored 0.610, global Jina-tiny reranking scored 0.588, and the post-hoc code-only reranking policy scored 0.638.
+
+The exact-edge guardrail remains 4/4 for Tessera versus 3/4 for CodeGraph. These graph cases measure exact target correctness, not retrieval ranking.
+
+## Normalized Code Retrieval
+
+Both engines are reduced to ordered source-file paths and scored against the same expected files.
+
+| Engine | Queries | MRR@10 | Top-1 | Top-3 | Top-10 | Mean latency | P95 latency |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| tessera_bge_small | 23 | 0.506 | 43% | 57% | 61% | 50 ms | 120 ms |
+| tessera_bge_small_jina_tiny | 23 | 0.577 | 48% | 65% | 74% | 769 ms | 1038 ms |
+| codegraph | 23 | 0.413 | 35% | 48% | 48% | 2931 ms | 5550 ms |
+
+Latency is directional: Tessera uses an in-process cached index, while CodeGraph is invoked as a fresh CLI process for each query.
+
+## Ranker Ablation Across All Content
+
+The routed policy is derived from the same measured rows: use Jina-tiny for code queries and preserve base hybrid ordering for document and mixed queries.
+
+| Tessera policy | Queries | MRR@10 | Top-1 | Top-3 | Top-10 |
+|---|---:|---:|---:|---:|---:|
+| BGE-small hybrid | 58 | 0.610 | 50% | 67% | 81% |
+| BGE-small + Jina-tiny globally | 58 | 0.588 | 47% | 66% | 83% |
+| BGE-small + Jina-tiny on code only (post-hoc) | 58 | 0.638 | 52% | 71% | 86% |
+
+## Benchmark-Driven Regression Fix
+
+The initial 14-case smoke run exposed a retrieval defect: the high-confidence BM25 shortcut could return chunks from only one file despite `file_dedup=True`, then skip semantic retrieval. Flask document Top-10 was 0/2 even though both targets were indexed.
+
+The fix over-fetches chunk candidates before file deduplication and declines the BM25 shortcut when it cannot fill the requested unique-file limit. Two red/green unit cases cover duplicate-heavy and single-hit pools.
+
+| Smoke configuration | MRR@10 before | MRR@10 after | Top-10 before | Top-10 after |
+|---|---:|---:|---:|---:|
+| BGE-small hybrid | 0.536 | 0.604 | 71% | 86% |
+| BGE-small + Jina-tiny | 0.554 | 0.648 | 71% | 93% |
+
+The Flask document subset improved from 0/2 to 2/2 Top-10 under both configurations. This smoke comparison uses the same queries and cached indexes before and after the search patch.
+
+## Language and Content Segments
+
+| Engine | Repository / segment | Queries | MRR@10 | Top-3 | Top-10 |
+|---|---|---:|---:|---:|---:|
+| codegraph | flask / code | 10 | 0.650 | 80% | 80% |
+| codegraph | nextjs / code | 13 | 0.231 | 23% | 23% |
+| tessera_bge_small | flask / code | 10 | 0.764 | 80% | 90% |
+| tessera_bge_small | flask / cross | 2 | 0.625 | 50% | 100% |
+| tessera_bge_small | flask / document | 8 | 0.679 | 88% | 100% |
+| tessera_bge_small | nextjs / code | 13 | 0.308 | 38% | 38% |
+| tessera_bge_small | nextjs / cross | 14 | 0.469 | 50% | 86% |
+| tessera_bge_small | nextjs / document | 11 | 0.955 | 100% | 100% |
+| tessera_bge_small_jina_tiny | flask / code | 10 | 0.650 | 70% | 70% |
+| tessera_bge_small_jina_tiny | flask / cross | 2 | 1.000 | 100% | 100% |
+| tessera_bge_small_jina_tiny | flask / document | 8 | 0.666 | 75% | 100% |
+| tessera_bge_small_jina_tiny | nextjs / code | 13 | 0.520 | 62% | 77% |
+| tessera_bge_small_jina_tiny | nextjs / cross | 14 | 0.370 | 43% | 71% |
+| tessera_bge_small_jina_tiny | nextjs / document | 11 | 0.756 | 82% | 100% |
+
+## Engineering Priorities
+
+1. **Gate reranking by content and language.** Jina-tiny improves Next.js code MRR from 0.308 to 0.520, but reduces Flask code from 0.764 to 0.650 and combined document retrieval from 0.839 to 0.718. Validate a TypeScript/code-only gate on an independent set before changing defaults.
+2. **Improve TypeScript candidate generation.** Even after reranking, Next.js code Top-10 is 77%; the remaining misses are webpack configuration, HMR, and static generation. These should become regression cases before tuning weights.
+3. **Sweep rankers behind the routed baseline.** Compare Jina tiny, turbo, and v3 (and code-specialized embedders such as CodeRankEmbed) per language/content segment rather than selecting on one aggregate.
+4. **Finish the broader benchmark program.** Expand the exact graph track beyond four collision cases, add independently authored relevance labels, and run process-normalized latency plus repeated agent-task evaluations.
+
+## Method and Definitions
+
+- **Corpus:** Next.js `adf8c612addd` and Flask `2c1b30d0503c`.
+- **Queries:** 58 unique ground-truth questions; each Tessera configuration runs all questions, while CodeGraph runs the source-code subset.
+- **MRR@10:** reciprocal rank of the first expected file, averaged across supported queries; a miss contributes zero.
+- **Top-k:** fraction of supported queries with any expected file in the first k unique file results.
+- **Documents:** Markdown, MDX, and reStructuredText are grouped as document retrieval. Unsupported CodeGraph rows are excluded rather than scored as failures.
+- **Tessera configuration:** BGE-small embeddings, hybrid retrieval, file deduplication; one run without reranking and one with Jina-tiny reranking.
+- **Routing ablation:** post-hoc selection from measured rows, not a third model execution; it should be confirmed on an independent query set before becoming a default.
+- **CodeGraph adapter:** ordered source-code file blocks emitted by `codegraph explore --max-files 10`.
+
+## Validation Assessment
+
+**Share with caveats.** File-level relevance labels and calculations are deterministic and machine-readable. The sample is broad enough to guide engineering priorities, but it is curated rather than independently blinded, and latency is not a process-normalized performance comparison.
+
+Recommended next step: inspect the per-query misses in the JSON artifact, then add the highest-impact failures as permanent regression cases before changing models or ranker weights.

--- a/docs/benchmark-search-quality.md
+++ b/docs/benchmark-search-quality.md
@@ -145,26 +145,26 @@ Before: only `json.dumps`. After: agents can request the format that suits their
 
 | Query | Search (ms) | + Snippet (ms) | + DocID (ms) | Total (ms) | Results |
 |-------|-----------|---------------|-------------|-----------|---------|
-| `normalize_bm25_score` | 0.57 | 1.10 | 0.03 | 1.69 | 10 |
-| `ProjectDB` | 0.42 | 0.77 | 0.02 | 1.21 | 10 |
-| `hybrid_search` | 1.02 | 1.18 | 0.02 | 2.23 | 10 |
-| `error handling` | 0.53 | 1.15 | 0.03 | 1.72 | 10 |
-| `authentication scope` | 0.58 | 1.54 | 0.03 | 2.15 | 10 |
-| `graph traversal` | 0.62 | 1.28 | 0.03 | 1.92 | 10 |
-| `keyword_search limit` | 1.00 | 1.53 | 0.03 | 2.56 | 10 |
-| `create_scope` | 0.79 | 0.81 | 0.02 | 1.61 | 10 |
-| `async to_thread` | 1.04 | 1.78 | 0.03 | 2.85 | 10 |
-| `FTS5 BM25` | 0.45 | 1.29 | 0.03 | 1.77 | 10 |
+| `normalize_bm25_score` | 0.58 | 1.10 | 0.03 | 1.71 | 10 |
+| `ProjectDB` | 0.41 | 0.76 | 0.02 | 1.20 | 10 |
+| `hybrid_search` | 0.99 | 1.25 | 0.02 | 2.26 | 10 |
+| `error handling` | 0.55 | 1.17 | 0.03 | 1.74 | 10 |
+| `authentication scope` | 0.60 | 1.56 | 0.03 | 2.19 | 10 |
+| `graph traversal` | 0.65 | 1.44 | 0.03 | 2.12 | 10 |
+| `keyword_search limit` | 1.01 | 1.48 | 0.03 | 2.52 | 10 |
+| `create_scope` | 0.84 | 0.84 | 0.02 | 1.70 | 10 |
+| `async to_thread` | 1.07 | 1.77 | 0.03 | 2.88 | 10 |
+| `FTS5 BM25` | 0.50 | 1.37 | 0.03 | 1.90 | 10 |
 
 **Full hybrid search** (embed + keyword + semantic + RRF + snippet + docid):
 
 | Query | Embed (ms) | Search (ms) | Post-process (ms) | Total (ms) |
 |-------|-----------|-----------|-------------------|-----------|
-| `normalize_bm25_score` | 0.0 | 9.4 | 0.57 | 10.0 |
-| `ProjectDB` | 0.0 | 8.3 | 2.98 | 11.3 |
-| `hybrid_search` | 0.0 | 9.1 | 2.01 | 11.2 |
-| `error handling` | 0.0 | 8.6 | 0.43 | 9.1 |
-| `authentication scope` | 0.0 | 8.2 | 0.72 | 9.0 |
+| `normalize_bm25_score` | 0.0 | 11.9 | 0.54 | 12.5 |
+| `ProjectDB` | 0.0 | 12.5 | 2.95 | 15.5 |
+| `hybrid_search` | 0.0 | 26.4 | 2.24 | 28.7 |
+| `error handling` | 0.0 | 10.3 | 0.41 | 10.7 |
+| `authentication scope` | 0.0 | 10.0 | 0.76 | 10.7 |
 
 ## 7. BM25 Strong-Signal Short-Circuit
 
@@ -188,11 +188,11 @@ Saves ~30-50ms per query when keyword match is unambiguous.
 
 | Query | Full Pipeline (ms) | Short-Circuit (ms) | Saved (ms) | Triggered? |
 |-------|-------------------|-------------------|-----------|-----------|
-| `normalize_bm25_score` | 132.9 | 0.7 | +132.2 | No |
-| `ProjectDB` | 8.8 | 0.5 | +8.3 | No |
-| `hybrid_search` | 8.9 | 0.9 | +7.9 | No |
-| `error handling` | 8.2 | 0.5 | +7.7 | No |
-| `authentication scope` | 7.5 | 0.6 | +6.9 | No |
+| `normalize_bm25_score` | 10.1 | 0.6 | +9.4 | No |
+| `ProjectDB` | 10.3 | 0.5 | +9.8 | No |
+| `hybrid_search` | 9.9 | 1.1 | +8.8 | No |
+| `error handling` | 9.5 | 0.6 | +8.9 | No |
+| `authentication scope` | 9.5 | 0.7 | +8.8 | No |
 
 ## 8. Weighted RRF Fusion
 
@@ -288,10 +288,10 @@ Keyword results boosted because FTS5 precision is higher for code search.
 
 | Query | Safe (ms) | Advanced (ms) |
 |-------|----------|-------------|
-| `hybrid_search` | 0.77 | 0.75 |
-| `"def hybrid_search"` | 0.99 | 0.94 |
-| `error NOT warning` | 0.69 | 0.39 |
-| `hybrid*` | 0.46 | 0.56 |
+| `hybrid_search` | 0.81 | 0.78 |
+| `"def hybrid_search"` | 1.05 | 0.97 |
+| `error NOT warning` | 0.69 | 0.41 |
+| `hybrid*` | 0.47 | 0.59 |
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,9 @@ Tessera uses git to detect changed files. Only modified code is re-parsed and re
 
 ## Start the MCP Server
 
-The MCP server exposes 19 tools to search, navigate, and analyze code. You can run it in two modes:
+By default, the MCP server exposes one task-oriented `explore` tool. It returns
+a bounded code-search, file-outline, and reference context pack suited to coding
+agents. Use the advanced profile when an integration needs the full 20-tool API.
 
 ### Single-Project Mode (locked to one project)
 
@@ -133,7 +135,8 @@ The MCP server exposes 19 tools to search, navigate, and analyze code. You can r
 uv run python -m tessera serve --project /path/to/your/project
 ```
 
-This locks the server to a single project. All MCP tools query only that project's index.
+This locks the server to a single project. The default `explore` tool queries only
+that project's index.
 
 ### Multi-Project Mode (no lock)
 
@@ -141,7 +144,17 @@ This locks the server to a single project. All MCP tools query only that project
 uv run python -m tessera serve
 ```
 
-The server can query multiple projects. You must register projects first (via `register_project` tool or from Claude Code).
+The server can query multiple projects. To register projects or use the specialized
+tools, start it with `--tool-profile advanced`.
+
+### Advanced Tool Profile
+
+```bash
+uv run python -m tessera serve --project /path/to/your/project --tool-profile advanced
+```
+
+This exposes `explore` plus the 19 specialized search, symbol, graph, scope, and
+collection tools for existing integrations and targeted investigation.
 
 ### With Embedding Support
 
@@ -246,7 +259,7 @@ To query multiple projects, use multi-project mode:
 }
 ```
 
-After saving `.mcp.json`, restart Claude Code (or toggle the MCP server in Settings). The tessera server will load and its 19 tools become available.
+After saving `.mcp.json`, restart Claude Code (or toggle the MCP server in Settings). The tessera server will load with `explore`; add `--tool-profile advanced` to the args when the full 20-tool API is needed.
 
 ## Embedding Server Setup (Optional)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ Tessera uses git to detect changed files. Only modified code is re-parsed and re
 
 ## Start the MCP Server
 
-The MCP server exposes 18 tools to search, navigate, and analyze code. You can run it in two modes:
+The MCP server exposes 19 tools to search, navigate, and analyze code. You can run it in two modes:
 
 ### Single-Project Mode (locked to one project)
 
@@ -246,7 +246,7 @@ To query multiple projects, use multi-project mode:
 }
 ```
 
-After saving `.mcp.json`, restart Claude Code (or toggle the MCP server in Settings). The tessera server will load and its 18 tools become available.
+After saving `.mcp.json`, restart Claude Code (or toggle the MCP server in Settings). The tessera server will load and its 19 tools become available.
 
 ## Embedding Server Setup (Optional)
 

--- a/docs/plans/phase5-ppr-graph/spike-results.md
+++ b/docs/plans/phase5-ppr-graph/spike-results.md
@@ -1,6 +1,6 @@
 # Phase 5a Spike Test Results — PPR Precision Validation
 
-**Date:** 2026-03-07 21:50:04
+**Date:** 2026-03-08 04:37:48
 **Status:** PRELIMINARY (automated test harness, not full annotation study)
 
 ## Executive Summary
@@ -24,20 +24,20 @@ Spike test validates PPR graph signal feasibility by:
 **Path:** /Users/danieliser/Toolkit/codemem/src/tessera
 
 **Indexing Results:**
-- Files indexed: 44
-- Symbols extracted: 656
-- Chunks created: 253
+- Files indexed: 45
+- Symbols extracted: 667
+- Chunks created: 256
 - Index time: 0.43s
 
 **Graph Metrics:**
-- Symbol count: 656
-- Edge count: 660
-- Edge/Symbol ratio: 1.01
-- Sparse (edges < symbols): False
-- **Assessment:** DENSE (good PPR signal expected)
+- Symbol count: 667
+- Edge count: 666
+- Edge/Symbol ratio: 1.00
+- Sparse (edges < symbols): True
+- **Assessment:** SPARSE (PPR may degrade gracefully)
 
 **PPR Performance:**
-- Computation time: 0.84ms
+- Computation time: 0.88ms
 - **Gate:** ✅ <100ms (passed)
 
 ---
@@ -104,9 +104,9 @@ Test validated:
 
 | Metric | Value | Gate | Status |
 |--------|-------|------|--------|
-| Tessera PPR time | 0.84ms | <100ms | ✅ |
-| Avg PPR time (all projects) | 0.84ms | <100ms | ✅ |
-| Max PPR time | 0.84ms | <100ms | ✅ |
+| Tessera PPR time | 0.88ms | <100ms | ✅ |
+| Avg PPR time (all projects) | 0.88ms | <100ms | ✅ |
+| Max PPR time | 0.88ms | <100ms | ✅ |
 
 ---
 

--- a/scripts/benchmark_competitive.py
+++ b/scripts/benchmark_competitive.py
@@ -346,6 +346,28 @@ def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def ranker_routing_analysis(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Score a post-hoc policy that reranks code but preserves base order elsewhere."""
+    routed = [
+        {**row, "engine": "tessera_code_only_rerank"}
+        for row in rows
+        if (
+            row["engine"] == "tessera_bge_small_jina_tiny"
+            if row["category"] == "code"
+            else row["engine"] == "tessera_bge_small"
+        )
+    ]
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in routed:
+        by_category[row["category"]].append(row)
+    return {
+        "policy": "Jina-tiny reranking for code; base hybrid order for document and cross queries",
+        "post_hoc": True,
+        "overall": summarize(routed),
+        "categories": {category: summarize(category_rows) for category, category_rows in sorted(by_category.items())},
+    }
+
+
 def run_cross_file_suite(codegraph_cli: Path, node_binary: str) -> dict[str, Any]:
     """Run the exact cross-file target suite and parse its JSON output."""
     completed = subprocess.run(
@@ -377,6 +399,8 @@ def render_report(report: dict[str, Any]) -> str:
     graph = report["graph_resolution"]
     reranked = comparable["tessera_bge_small_jina_tiny"]
     codegraph = comparable["codegraph"]
+    overall = report["summary"]["overall"]
+    routed = report["summary"]["ranker_routing"]["overall"]
     winner = "Tessera" if reranked["mrr_at_10"] >= codegraph["mrr_at_10"] else "CodeGraph"
     lines = [
         "# Tessera vs CodeGraph: Python, TypeScript, and Documentation Benchmark",
@@ -390,6 +414,11 @@ def render_report(report: dict[str, Any]) -> str:
         f"CodeGraph scored {codegraph['mrr_at_10']:.3f} across the same Python and "
         "TypeScript query set. Tessera also covers document and mixed-source queries, "
         "which CodeGraph does not index and which are therefore reported separately.",
+        "",
+        "Across all Tessera-supported content, reranking every query is counterproductive: "
+        f"base hybrid retrieval scored {overall['tessera_bge_small']['mrr_at_10']:.3f}, "
+        f"global Jina-tiny reranking scored {overall['tessera_bge_small_jina_tiny']['mrr_at_10']:.3f}, "
+        f"and the post-hoc code-only reranking policy scored {routed['mrr_at_10']:.3f}.",
         "",
         f"The exact-edge guardrail remains {graph['tessera']['passed']}/{graph['tessera']['total']} "
         f"for Tessera versus {graph['codegraph']['passed']}/{graph['codegraph']['total']} "
@@ -413,6 +442,25 @@ def render_report(report: dict[str, Any]) -> str:
     lines += [
         "",
         "Latency is directional: Tessera uses an in-process cached index, while CodeGraph is invoked as a fresh CLI process for each query.",
+        "",
+        "## Ranker Ablation Across All Content",
+        "",
+        "The routed policy is derived from the same measured rows: use Jina-tiny for code queries and preserve base hybrid ordering for document and mixed queries.",
+        "",
+        "| Tessera policy | Queries | MRR@10 | Top-1 | Top-3 | Top-10 |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for label, metric in (
+        ("BGE-small hybrid", overall["tessera_bge_small"]),
+        ("BGE-small + Jina-tiny globally", overall["tessera_bge_small_jina_tiny"]),
+        ("BGE-small + Jina-tiny on code only (post-hoc)", routed),
+    ):
+        lines.append(
+            f"| {label} | {metric['queries_supported']} | {metric['mrr_at_10']:.3f} | "
+            f"{_format_pct(metric['top_1'])} | {_format_pct(metric['top_3'])} | "
+            f"{_format_pct(metric['top_10'])} |"
+        )
+    lines += [
         "",
         "## Language and Content Segments",
         "",
@@ -440,6 +488,7 @@ def render_report(report: dict[str, Any]) -> str:
         "- **Top-k:** fraction of supported queries with any expected file in the first k unique file results.",
         "- **Documents:** Markdown, MDX, and reStructuredText are grouped as document retrieval. Unsupported CodeGraph rows are excluded rather than scored as failures.",
         "- **Tessera configuration:** BGE-small embeddings, hybrid retrieval, file deduplication; one run without reranking and one with Jina-tiny reranking.",
+        "- **Routing ablation:** post-hoc selection from measured rows, not a third model execution; it should be confirmed on an independent query set before becoming a default.",
         "- **CodeGraph adapter:** ordered source-code file blocks emitted by `codegraph explore --max-files 10`.",
         "",
         "## Validation Assessment",
@@ -480,7 +529,6 @@ def main() -> int:
         paths[name] = path
         revision = _version(["git", "rev-parse", "HEAD"], cwd=path)
         repositories[name] = {
-            "path": str(path),
             "revision": revision,
             "configured_ref": CODEBASES[name]["ref"],
             "languages": CODEBASES[name]["languages"],
@@ -517,6 +565,8 @@ def main() -> int:
             completed_runs += 1
             print(f"[{completed_runs}/{total_runs}] codegraph: {case['repository']} / {case['description']}")
 
+    summary = aggregate(rows)
+    summary["ranker_routing"] = ranker_routing_analysis(rows)
     output = {
         "metadata": {
             "generated_at": datetime.now(UTC).isoformat(),
@@ -532,7 +582,7 @@ def main() -> int:
             "reranking_model": RERANKER_JINA_TINY,
         },
         "repositories": repositories,
-        "summary": aggregate(rows),
+        "summary": summary,
         "graph_resolution": run_cross_file_suite(args.codegraph_cli, args.node_binary),
         "queries": rows,
         "limitations": [

--- a/scripts/benchmark_competitive.py
+++ b/scripts/benchmark_competitive.py
@@ -1,0 +1,559 @@
+"""Run a reproducible Tessera vs CodeGraph retrieval benchmark.
+
+The benchmark uses pinned Next.js and Flask checkouts to cover TypeScript,
+Python, Markdown/MDX, reStructuredText, and mixed code/document queries. Both
+engines are reduced to an ordered list of file paths before scoring. CodeGraph
+is marked unsupported for document and mixed-content queries because it does
+not index those sources; unsupported rows never count as misses.
+
+Example:
+    CODEGRAPH_NODE=~/.nvm/versions/node/v22.19.0/bin/node \
+      uv run python scripts/benchmark_competitive.py \
+      --codegraph-cli /tmp/codegraph-review/dist/bin/codegraph.js \
+      --output benchmarks/competitive-2026-07-14.json \
+      --report docs/benchmark-competitive-2026-07-14.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATION_DIR = Path(__file__).resolve().parent / "benchmark_validation"
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from benchmark_validation.run import (  # noqa: E402
+    CODEBASES,
+    ensure_codebase,
+    index_codebase,
+)
+
+from tessera.embeddings import FastembedClient, FastembedReranker  # noqa: E402
+from tessera.model_profiles import RERANKER_JINA_TINY  # noqa: E402
+from tessera.search import hybrid_search  # noqa: E402
+
+TOP_K = 10
+RERANK_POOL = 40
+DOCUMENT_SOURCE_TYPES = [
+    "markdown",
+    "pdf",
+    "yaml",
+    "json",
+    "html",
+    "xml",
+    "text",
+    "txt",
+    "rst",
+    "csv",
+    "tsv",
+    "log",
+    "ini",
+    "cfg",
+    "toml",
+    "conf",
+]
+CODE_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".jsx"}
+DOCUMENT_EXTENSIONS = {
+    ".md",
+    ".mdx",
+    ".pdf",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".html",
+    ".htm",
+    ".xml",
+    ".xsl",
+    ".xslt",
+    ".svg",
+    ".txt",
+    ".rst",
+    ".csv",
+    ".tsv",
+    ".log",
+    ".ini",
+    ".cfg",
+    ".toml",
+    ".conf",
+}
+CODEGRAPH_FILE = re.compile(r"^\*\*`([^`]+)`\*\*", re.MULTILINE)
+
+
+def _matches_expected(path: str, expected: list[str]) -> bool:
+    normalized = path.replace("\\", "/").casefold()
+    return any(item.replace("\\", "/").casefold() in normalized for item in expected)
+
+
+def rank_expected(paths: list[str], expected: list[str], k: int = TOP_K) -> int | None:
+    """Return the one-based rank of the first expected file."""
+    for index, path in enumerate(paths[:k], start=1):
+        if _matches_expected(path, expected):
+            return index
+    return None
+
+
+def parse_codegraph_files(output: str) -> list[str]:
+    """Extract ordered source-file blocks from CodeGraph explore output."""
+    seen: set[str] = set()
+    paths: list[str] = []
+    for path in CODEGRAPH_FILE.findall(output):
+        if path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percentile
+    low = math.floor(position)
+    high = math.ceil(position)
+    if low == high:
+        return ordered[low]
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate supported query rows without treating unsupported as misses."""
+    supported = [row for row in rows if row["supported"]]
+    latencies = [float(row["latency_ms"]) for row in supported]
+    ranks = [row["rank"] for row in supported]
+    count = len(supported)
+    return {
+        "queries_total": len(rows),
+        "queries_supported": count,
+        "queries_unsupported": len(rows) - count,
+        "mrr_at_10": (round(sum(1.0 / rank for rank in ranks if rank is not None) / count, 4) if count else 0.0),
+        "top_1": round(sum(rank == 1 for rank in ranks) / count, 4) if count else 0.0,
+        "top_3": round(sum(rank is not None and rank <= 3 for rank in ranks) / count, 4) if count else 0.0,
+        "top_5": round(sum(rank is not None and rank <= 5 for rank in ranks) / count, 4) if count else 0.0,
+        "top_10": round(sum(rank is not None for rank in ranks) / count, 4) if count else 0.0,
+        "latency_ms_mean": round(statistics.fmean(latencies), 2) if latencies else 0.0,
+        "latency_ms_p50": round(statistics.median(latencies), 2) if latencies else 0.0,
+        "latency_ms_p95": round(_percentile(latencies, 0.95), 2) if latencies else 0.0,
+    }
+
+
+def _query_module(codebase: str):
+    return importlib.import_module(f"benchmark_validation.{CODEBASES[codebase]['queries']}")
+
+
+def load_cases(codebase: str, tier: str) -> list[dict[str, Any]]:
+    """Load the versioned ground-truth cases for one repository."""
+    language = "typescript" if codebase == "nextjs" else "python"
+    cases = []
+    for query, expected, description, category, query_tier in _query_module(codebase).get_queries(tier):
+        cases.append(
+            {
+                "repository": codebase,
+                "language": language,
+                "category": "document" if category == "doc" else category,
+                "tier": query_tier,
+                "query": query,
+                "description": description,
+                "expected_files": expected,
+            }
+        )
+    return cases
+
+
+def _source_filter(category: str) -> list[str] | None:
+    if category == "code":
+        return ["code"]
+    if category == "document":
+        return DOCUMENT_SOURCE_TYPES
+    return None
+
+
+def validate_ground_truth(cases: list[dict[str, Any]], paths: dict[str, Path]) -> None:
+    """Fail when a label cannot resolve to a category-compatible corpus file."""
+    corpus: dict[str, list[str]] = {}
+    for repository, root in paths.items():
+        corpus[repository] = [
+            path.relative_to(root).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and ".git" not in path.parts and ".codegraph" not in path.parts
+        ]
+
+    invalid: list[str] = []
+    for case in cases:
+        candidates = corpus[case["repository"]]
+        if case["category"] == "code":
+            candidates = [path for path in candidates if Path(path).suffix in CODE_EXTENSIONS]
+        elif case["category"] == "document":
+            candidates = [path for path in candidates if Path(path).suffix in DOCUMENT_EXTENSIONS]
+        if not any(_matches_expected(path, case["expected_files"]) for path in candidates):
+            invalid.append(f"{case['repository']} / {case['description']}: {case['expected_files']}")
+
+    if invalid:
+        details = "\n".join(f"- {item}" for item in invalid)
+        raise ValueError(f"Ground-truth labels do not resolve in the pinned corpus:\n{details}")
+
+
+def _dedupe_paths(hits: list[dict[str, Any]]) -> list[str]:
+    seen: set[str] = set()
+    paths: list[str] = []
+    for hit in hits:
+        path = str(hit.get("file_path", ""))
+        if path and path not in seen:
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def run_tessera_case(
+    case: dict[str, Any],
+    db: Any,
+    embedder: FastembedClient,
+    reranker: FastembedReranker | None,
+    engine: str,
+) -> dict[str, Any]:
+    """Run one Tessera query and normalize it to ranked file paths."""
+    started = time.perf_counter()
+    embedding = np.array(embedder.embed_query(case["query"]), dtype=np.float32)
+    hits = hybrid_search(
+        case["query"],
+        embedding,
+        db,
+        graph=None,
+        limit=RERANK_POOL,
+        source_type=_source_filter(case["category"]),
+        file_dedup=True,
+    )
+    if reranker and hits:
+        documents = [hit.get("content", "")[:1024] for hit in hits]
+        reranked = reranker.rerank(case["query"], documents, top_k=TOP_K)
+        hits = [hits[index] for index, _score in reranked if index < len(hits)]
+    paths = _dedupe_paths(hits)[:TOP_K]
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    rank = rank_expected(paths, case["expected_files"])
+    return {
+        **case,
+        "engine": engine,
+        "supported": True,
+        "rank": rank,
+        "reciprocal_rank": round(1.0 / rank, 4) if rank else 0.0,
+        "top_files": paths,
+        "latency_ms": round(elapsed_ms, 2),
+    }
+
+
+def run_codegraph_case(
+    case: dict[str, Any],
+    project_path: Path,
+    codegraph_cli: Path,
+    node_binary: str,
+) -> dict[str, Any]:
+    """Run one CodeGraph query or mark unsupported source categories."""
+    if case["category"] != "code":
+        return {
+            **case,
+            "engine": "codegraph",
+            "supported": False,
+            "unsupported_reason": "CodeGraph indexes source code, not Markdown/document content",
+            "rank": None,
+            "reciprocal_rank": None,
+            "top_files": [],
+            "latency_ms": None,
+        }
+    started = time.perf_counter()
+    completed = subprocess.run(
+        [
+            node_binary,
+            str(codegraph_cli),
+            "explore",
+            "--path",
+            str(project_path),
+            "--max-files",
+            str(TOP_K),
+            case["query"],
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    paths = parse_codegraph_files(completed.stdout)[:TOP_K]
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    rank = rank_expected(paths, case["expected_files"])
+    return {
+        **case,
+        "engine": "codegraph",
+        "supported": True,
+        "rank": rank,
+        "reciprocal_rank": round(1.0 / rank, 4) if rank else 0.0,
+        "top_files": paths,
+        "latency_ms": round(elapsed_ms, 2),
+    }
+
+
+def ensure_codegraph_index(project_path: Path, codegraph_cli: Path, node_binary: str) -> dict[str, Any]:
+    """Initialize CodeGraph when needed and return index metadata."""
+    database = project_path / ".codegraph" / "codegraph.db"
+    cached = database.exists()
+    started = time.perf_counter()
+    if not cached:
+        subprocess.run(
+            [node_binary, str(codegraph_cli), "init", str(project_path)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=300,
+        )
+    return {
+        "cached": cached,
+        "setup_ms": round((time.perf_counter() - started) * 1000, 2),
+    }
+
+
+def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build overall and per-repository/category summaries."""
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    by_engine: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    comparable_code: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(row["engine"], row["repository"], row["category"])].append(row)
+        by_engine[row["engine"]].append(row)
+        if row["category"] == "code":
+            comparable_code[row["engine"]].append(row)
+    return {
+        "overall": {engine: summarize(engine_rows) for engine, engine_rows in by_engine.items()},
+        "comparable_code": {engine: summarize(engine_rows) for engine, engine_rows in comparable_code.items()},
+        "segments": {
+            f"{engine}/{repository}/{category}": summarize(segment_rows)
+            for (engine, repository, category), segment_rows in sorted(grouped.items())
+        },
+    }
+
+
+def run_cross_file_suite(codegraph_cli: Path, node_binary: str) -> dict[str, Any]:
+    """Run the exact cross-file target suite and parse its JSON output."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "benchmark_cross_file_resolution.py"),
+            "--codegraph-cli",
+            str(codegraph_cli),
+            "--node-binary",
+            node_binary,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=REPO_ROOT,
+    )
+    return json.loads(completed.stdout)
+
+
+def _format_pct(value: float) -> str:
+    return f"{value:.0%}"
+
+
+def render_report(report: dict[str, Any]) -> str:
+    """Render an answer-first Markdown benchmark report."""
+    comparable = report["summary"]["comparable_code"]
+    segments = report["summary"]["segments"]
+    graph = report["graph_resolution"]
+    reranked = comparable["tessera_bge_small_jina_tiny"]
+    codegraph = comparable["codegraph"]
+    winner = "Tessera" if reranked["mrr_at_10"] >= codegraph["mrr_at_10"] else "CodeGraph"
+    lines = [
+        "# Tessera vs CodeGraph: Python, TypeScript, and Documentation Benchmark",
+        "",
+        f"*Generated {report['metadata']['generated_at']} from pinned Flask and Next.js revisions.*",
+        "",
+        "## Technical Summary",
+        "",
+        f"**{winner} leads the normalized source-code comparison on MRR@10.** "
+        f"Tessera with BGE-small + Jina-tiny scored {reranked['mrr_at_10']:.3f}; "
+        f"CodeGraph scored {codegraph['mrr_at_10']:.3f} across the same Python and "
+        "TypeScript query set. Tessera also covers document and mixed-source queries, "
+        "which CodeGraph does not index and which are therefore reported separately.",
+        "",
+        f"The exact-edge guardrail remains {graph['tessera']['passed']}/{graph['tessera']['total']} "
+        f"for Tessera versus {graph['codegraph']['passed']}/{graph['codegraph']['total']} "
+        "for CodeGraph. These graph cases measure exact target correctness, not retrieval ranking.",
+        "",
+        "## Normalized Code Retrieval",
+        "",
+        "Both engines are reduced to ordered source-file paths and scored against the same expected files.",
+        "",
+        "| Engine | Queries | MRR@10 | Top-1 | Top-3 | Top-10 | Mean latency | P95 latency |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for engine in ("tessera_bge_small", "tessera_bge_small_jina_tiny", "codegraph"):
+        metric = comparable[engine]
+        lines.append(
+            f"| {engine} | {metric['queries_supported']} | {metric['mrr_at_10']:.3f} | "
+            f"{_format_pct(metric['top_1'])} | {_format_pct(metric['top_3'])} | "
+            f"{_format_pct(metric['top_10'])} | {metric['latency_ms_mean']:.0f} ms | "
+            f"{metric['latency_ms_p95']:.0f} ms |"
+        )
+    lines += [
+        "",
+        "Latency is directional: Tessera uses an in-process cached index, while CodeGraph is invoked as a fresh CLI process for each query.",
+        "",
+        "## Language and Content Segments",
+        "",
+        "| Engine | Repository / segment | Queries | MRR@10 | Top-3 | Top-10 |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for key, metric in segments.items():
+        engine, repository, category = key.split("/")
+        if metric["queries_supported"] == 0:
+            continue
+        lines.append(
+            f"| {engine} | {repository} / {category} | {metric['queries_supported']} | "
+            f"{metric['mrr_at_10']:.3f} | {_format_pct(metric['top_3'])} | "
+            f"{_format_pct(metric['top_10'])} |"
+        )
+    lines += [
+        "",
+        "## Method and Definitions",
+        "",
+        f"- **Corpus:** Next.js `{report['repositories']['nextjs']['revision'][:12]}` and Flask "
+        f"`{report['repositories']['flask']['revision'][:12]}`.",
+        f"- **Queries:** {report['metadata']['query_cases']} unique ground-truth questions; each Tessera "
+        "configuration runs all questions, while CodeGraph runs the source-code subset.",
+        "- **MRR@10:** reciprocal rank of the first expected file, averaged across supported queries; a miss contributes zero.",
+        "- **Top-k:** fraction of supported queries with any expected file in the first k unique file results.",
+        "- **Documents:** Markdown, MDX, and reStructuredText are grouped as document retrieval. Unsupported CodeGraph rows are excluded rather than scored as failures.",
+        "- **Tessera configuration:** BGE-small embeddings, hybrid retrieval, file deduplication; one run without reranking and one with Jina-tiny reranking.",
+        "- **CodeGraph adapter:** ordered source-code file blocks emitted by `codegraph explore --max-files 10`.",
+        "",
+        "## Validation Assessment",
+        "",
+        "**Share with caveats.** File-level relevance labels and calculations are deterministic and machine-readable. "
+        "The sample is broad enough to guide engineering priorities, but it is curated rather than independently blinded, "
+        "and latency is not a process-normalized performance comparison.",
+        "",
+        "Recommended next step: inspect the per-query misses in the JSON artifact, then add the highest-impact failures as permanent regression cases before changing models or ranker weights.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _version(command: list[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(command, capture_output=True, text=True, cwd=cwd, check=True)
+    return completed.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--codegraph-cli", type=Path, required=True)
+    parser.add_argument(
+        "--node-binary",
+        default=os.environ.get("CODEGRAPH_NODE") or shutil.which("node") or "node",
+    )
+    parser.add_argument("--tier", choices=["quick", "standard", "full"], default="standard")
+    parser.add_argument("--reindex", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+
+    repositories = {}
+    cases = []
+    paths: dict[str, Path] = {}
+    for name in ("nextjs", "flask"):
+        path = Path(ensure_codebase(name))
+        paths[name] = path
+        revision = _version(["git", "rev-parse", "HEAD"], cwd=path)
+        repositories[name] = {
+            "path": str(path),
+            "revision": revision,
+            "configured_ref": CODEBASES[name]["ref"],
+            "languages": CODEBASES[name]["languages"],
+            "codegraph_index": ensure_codegraph_index(path, args.codegraph_cli, args.node_binary),
+        }
+        cases.extend(load_cases(name, args.tier))
+
+    validate_ground_truth(cases, paths)
+
+    embedder = FastembedClient(model_name="BAAI/bge-small-en-v1.5")
+    _ = embedder.embed_query("benchmark warmup")
+    reranker = FastembedReranker(model_name=RERANKER_JINA_TINY)
+    _ = reranker.rerank("benchmark", ["benchmark warmup"], top_k=1)
+
+    databases = {}
+    for name, path in paths.items():
+        databases[name] = index_codebase(name, str(path), embedder, model_key="bge-small", reindex=args.reindex)
+
+    rows: list[dict[str, Any]] = []
+    total_runs = len(cases) * 2 + sum(case["category"] == "code" for case in cases)
+    completed_runs = 0
+    for case in cases:
+        for engine, selected_reranker in (
+            ("tessera_bge_small", None),
+            ("tessera_bge_small_jina_tiny", reranker),
+        ):
+            rows.append(run_tessera_case(case, databases[case["repository"]], embedder, selected_reranker, engine))
+            completed_runs += 1
+            print(f"[{completed_runs}/{total_runs}] {engine}: {case['repository']} / {case['description']}")
+
+        codegraph_row = run_codegraph_case(case, paths[case["repository"]], args.codegraph_cli, args.node_binary)
+        rows.append(codegraph_row)
+        if codegraph_row["supported"]:
+            completed_runs += 1
+            print(f"[{completed_runs}/{total_runs}] codegraph: {case['repository']} / {case['description']}")
+
+    output = {
+        "metadata": {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "tier": args.tier,
+            "query_cases": len(cases),
+            "measured_query_runs": total_runs,
+            "top_k": TOP_K,
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "tessera_revision": _version(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT),
+            "codegraph_version": _version([args.node_binary, str(args.codegraph_cli), "--version"]),
+            "embedding_model": "BAAI/bge-small-en-v1.5",
+            "reranking_model": RERANKER_JINA_TINY,
+        },
+        "repositories": repositories,
+        "summary": aggregate(rows),
+        "graph_resolution": run_cross_file_suite(args.codegraph_cli, args.node_binary),
+        "queries": rows,
+        "limitations": [
+            "CodeGraph does not index Markdown/document content; unsupported rows are excluded.",
+            "Tessera runs in-process while CodeGraph launches a CLI process per query; latency is directional.",
+            "Ground truth is curated and file-level; it does not score answer synthesis or snippet quality.",
+            "Cached indexes are used unless --reindex is supplied, so setup_ms is not a cold-index benchmark.",
+        ],
+    }
+
+    rendered = json.dumps(output, indent=2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(render_report(output), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_cross_file_resolution.py
+++ b/scripts/benchmark_cross_file_resolution.py
@@ -1,0 +1,200 @@
+"""Compare Tessera and CodeGraph on exact cross-file call resolution.
+
+The fixture deliberately includes same-named unrelated functions. A benchmark
+counts a case as correct only when the call edge reaches the expected file and
+symbol, never merely when a same-named target exists somewhere in the graph.
+
+Usage:
+    uv run python scripts/benchmark_cross_file_resolution.py \
+        --codegraph-cli /path/to/codegraph/dist/bin/codegraph.js
+
+Set CODEGRAPH_NODE when the CodeGraph checkout requires a particular Node.js
+binary (for example, Node 22 LTS).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from tessera.db import ProjectDB
+from tessera.indexer import IndexerPipeline
+
+
+@dataclass(frozen=True)
+class Case:
+    """One exact call-edge expectation in the generated fixture."""
+
+    name: str
+    caller_file: str
+    caller_symbol: str
+    target_file: str
+    target_symbol: str
+
+
+CASES = (
+    Case("python_named_alias", "caller_alias.py", "caller_alias", "service.py", "run"),
+    Case("python_module_call", "caller_module.py", "caller_module", "service.py", "run"),
+    Case("python_reexport", "caller_reexport.py", "caller_reexport", "service.py", "run"),
+    Case("typescript_named_alias", "caller_alias.ts", "callerAlias", "service.ts", "run"),
+)
+
+
+FIXTURE_FILES = {
+    "service.py": 'def run() -> str:\n    return "service"\n',
+    "facade.py": "from service import run\n\n__all__ = [\"run\"]\n",
+    "unrelated.py": 'def execute() -> str:\n    return "unrelated"\n\n\ndef run() -> str:\n    return "other"\n',
+    "caller_alias.py": "from service import run as execute\n\n\ndef caller_alias() -> str:\n    return execute()\n",
+    "caller_module.py": "import service\n\n\ndef caller_module() -> str:\n    return service.run()\n",
+    "caller_reexport.py": "from facade import run\n\n\ndef caller_reexport() -> str:\n    return run()\n",
+    "service.ts": "export function run(): string { return 'service'; }\n",
+    "unrelated.ts": "export function execute(): string { return 'unrelated'; }\n",
+    "caller_alias.ts": (
+        "import { run as execute } from './service';\n\n"
+        "export function callerAlias(): string { return execute(); }\n"
+    ),
+}
+
+
+def create_fixture(root: Path) -> None:
+    """Write the small, collision-heavy project used by both engines."""
+    for relative_path, content in FIXTURE_FILES.items():
+        (root / relative_path).write_text(content, encoding="utf-8")
+
+
+def score_targets(targets: dict[tuple[str, str], tuple[str, str] | None]) -> dict[str, bool]:
+    """Return one exact-match result per case from a caller-to-target mapping."""
+    return {
+        case.name: targets.get((case.caller_file, case.caller_symbol))
+        == (case.target_file, case.target_symbol)
+        for case in CASES
+    }
+
+
+def format_targets(
+    targets: dict[tuple[str, str], tuple[str, str] | None],
+) -> dict[str, tuple[str, str] | None]:
+    """Convert internal tuple keys into stable JSON object keys."""
+    return {
+        f"{source_file}:{caller_name}": target
+        for (source_file, caller_name), target in sorted(targets.items())
+    }
+
+
+def tessera_targets(project_root: Path, data_root: Path) -> tuple[dict[tuple[str, str], tuple[str, str] | None], float]:
+    """Index the fixture and return Tessera's resolved call targets."""
+    ProjectDB.base_dir = str(data_root)
+    pipeline = IndexerPipeline(str(project_root), languages=["python", "typescript"])
+    started = time.perf_counter()
+    pipeline.index_project_sync()
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    rows = pipeline.project_db.conn.execute(
+        """
+        SELECT source.path, caller.name, destination.path, target.name
+        FROM refs
+        JOIN symbols AS caller ON caller.id = refs.from_symbol_id
+        JOIN files AS source ON source.id = caller.file_id
+        LEFT JOIN symbols AS target ON target.id = refs.to_symbol_id
+        LEFT JOIN files AS destination ON destination.id = target.file_id
+        WHERE refs.kind = 'calls'
+        """
+    ).fetchall()
+    targets: dict[tuple[str, str], tuple[str, str] | None] = {}
+    for source_file, caller_name, target_file, target_name in rows:
+        if not isinstance(source_file, str) or not isinstance(caller_name, str):
+            continue
+        if isinstance(target_file, str) and isinstance(target_name, str):
+            targets[(source_file, caller_name)] = (target_file, target_name)
+        else:
+            targets[(source_file, caller_name)] = None
+    return targets, elapsed_ms
+
+
+def codegraph_targets(
+    project_root: Path, codegraph_cli: Path, node_binary: str
+) -> tuple[dict[tuple[str, str], tuple[str, str] | None], float]:
+    """Index with CodeGraph's CLI and query exact calls from its SQLite graph."""
+    started = time.perf_counter()
+    subprocess.run(
+        [node_binary, str(codegraph_cli), "init", str(project_root)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000
+
+    database_path = project_root / ".codegraph" / "codegraph.db"
+    with sqlite3.connect(database_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT source.file_path, source.name, target.file_path, target.name
+            FROM edges AS edge
+            JOIN nodes AS source ON source.id = edge.source
+            JOIN nodes AS target ON target.id = edge.target
+            WHERE edge.kind = 'calls'
+            """
+        ).fetchall()
+    targets: dict[tuple[str, str], tuple[str, str] | None] = {}
+    for source_file, caller_name, target_file, target_name in rows:
+        if all(isinstance(value, str) for value in (source_file, caller_name, target_file, target_name)):
+            targets[(source_file, caller_name)] = (target_file, target_name)
+    return targets, elapsed_ms
+
+
+def main() -> int:
+    """Run the suite and print a machine-readable comparison report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--codegraph-cli",
+        type=Path,
+        required=True,
+        help="Path to CodeGraph's dist/bin/codegraph.js",
+    )
+    parser.add_argument(
+        "--node-binary",
+        default=os.environ.get("CODEGRAPH_NODE") or shutil.which("node") or "node",
+        help="Node.js binary used to run CodeGraph (default: CODEGRAPH_NODE or PATH)",
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="tessera-codegraph-") as temporary_directory:
+        fixture_root = Path(temporary_directory) / "fixture"
+        fixture_root.mkdir()
+        create_fixture(fixture_root)
+
+        tessera, tessera_ms = tessera_targets(fixture_root, Path(temporary_directory) / "tessera")
+        codegraph, codegraph_ms = codegraph_targets(
+            fixture_root, args.codegraph_cli, args.node_binary
+        )
+
+        report = {
+            "cases": [asdict(case) for case in CASES],
+            "tessera": {
+                "cold_index_ms": round(tessera_ms, 2),
+                "resolved_targets": format_targets(tessera),
+                "passes": score_targets(tessera),
+            },
+            "codegraph": {
+                "cold_index_ms": round(codegraph_ms, 2),
+                "resolved_targets": format_targets(codegraph),
+                "passes": score_targets(codegraph),
+            },
+        }
+        for engine in ("tessera", "codegraph"):
+            report[engine]["passed"] = sum(report[engine]["passes"].values())
+            report[engine]["total"] = len(CASES)
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_validation/queries_flask.py
+++ b/scripts/benchmark_validation/queries_flask.py
@@ -1,0 +1,164 @@
+"""Flask 3.1.2 validation queries, verified against the pinned repository."""
+
+QUICK_CODE = [
+    (
+        "request dispatch and view function invocation",
+        ["src/flask/app.py"],
+        "Find request dispatch implementation",
+        "code",
+        "quick",
+    ),
+    (
+        "secure cookie session loading and saving",
+        ["src/flask/sessions.py"],
+        "Find secure cookie sessions",
+        "code",
+        "quick",
+    ),
+    (
+        "render a Jinja template with context processors",
+        ["src/flask/templating.py"],
+        "Find template rendering",
+        "code",
+        "quick",
+    ),
+]
+
+QUICK_DOC = [
+    (
+        "organize a Flask application with blueprints",
+        ["docs/blueprints.rst"],
+        "Find blueprint documentation",
+        "doc",
+        "quick",
+    ),
+    (
+        "create and configure an application factory",
+        ["docs/patterns/appfactories.rst"],
+        "Find application factory guide",
+        "doc",
+        "quick",
+    ),
+]
+
+QUICK_CROSS = [
+    (
+        "how Flask handles exceptions and registered error handlers",
+        ["src/flask/app.py", "docs/errorhandling.rst"],
+        "Find error handling code or guide",
+        "cross",
+        "quick",
+    ),
+    (
+        "application and request context push pop lifecycle",
+        ["src/flask/ctx.py", "docs/reqcontext.rst", "docs/appcontext.rst"],
+        "Find context lifecycle code or docs",
+        "cross",
+        "quick",
+    ),
+]
+
+STANDARD_CODE = [
+    (
+        "convert a view return value into a response object",
+        ["src/flask/app.py", "src/flask/helpers.py"],
+        "Find response conversion",
+        "code",
+        "standard",
+    ),
+    (
+        "register a blueprint and deferred setup operations",
+        ["src/flask/sansio/blueprints.py", "src/flask/blueprints.py"],
+        "Find blueprint registration",
+        "code",
+        "standard",
+    ),
+    (
+        "generate URLs inside and outside a request context",
+        ["src/flask/app.py", "src/flask/helpers.py"],
+        "Find URL generation",
+        "code",
+        "standard",
+    ),
+    (
+        "class based views dispatch HTTP methods",
+        ["src/flask/views.py"],
+        "Find MethodView dispatch",
+        "code",
+        "standard",
+    ),
+    (
+        "discover and load an application for the flask command",
+        ["src/flask/cli.py"],
+        "Find CLI application discovery",
+        "code",
+        "standard",
+    ),
+    (
+        "serialize JSON responses with the default provider",
+        ["src/flask/json/provider.py"],
+        "Find JSON provider",
+        "code",
+        "standard",
+    ),
+    (
+        "run before request preprocessors in blueprint order",
+        ["src/flask/app.py"],
+        "Find request preprocessing",
+        "code",
+        "standard",
+    ),
+]
+
+STANDARD_DOC = [
+    (
+        "complete request handling lifecycle step by step",
+        ["docs/lifecycle.rst"],
+        "Find request lifecycle guide",
+        "doc",
+        "standard",
+    ),
+    (
+        "security headers content security policy and cookie settings",
+        ["docs/web-security.rst"],
+        "Find web security guidance",
+        "doc",
+        "standard",
+    ),
+    (
+        "use async await in route views",
+        ["docs/async-await.rst"],
+        "Find async view documentation",
+        "doc",
+        "standard",
+    ),
+    (
+        "test an application with pytest fixtures and the test client",
+        ["docs/testing.rst"],
+        "Find testing guide",
+        "doc",
+        "standard",
+    ),
+    (
+        "stream a response from a generator while keeping request context",
+        ["docs/patterns/streaming.rst"],
+        "Find streaming pattern",
+        "doc",
+        "standard",
+    ),
+    (
+        "sans io base classes separate framework logic from the web server",
+        ["src/flask/sansio/README.md"],
+        "Find Sans-IO Markdown architecture note",
+        "doc",
+        "standard",
+    ),
+]
+
+
+def get_queries(tier: str = "standard") -> list:
+    """Return cumulative Flask queries for quick or standard runs."""
+    queries = QUICK_CODE + QUICK_DOC + QUICK_CROSS
+    if tier in {"standard", "full"}:
+        queries += STANDARD_CODE + STANDARD_DOC
+    return queries

--- a/scripts/benchmark_validation/queries_nextjs.py
+++ b/scripts/benchmark_validation/queries_nextjs.py
@@ -132,7 +132,7 @@ STANDARD_DOC = [
         "middleware matching paths configuration",
         ["middleware-route-matcher.ts", "middleware-config.ts"],
         "Find middleware config docs",
-        "doc", "standard",
+        "cross", "standard",
     ),
     (
         "authentication and session management",

--- a/scripts/benchmark_validation/run.py
+++ b/scripts/benchmark_validation/run.py
@@ -33,6 +33,14 @@ CODEBASES = {
         "ref": "v16.1.6",
         "paths": ["packages/next/src", "docs"],
         "queries": "queries_nextjs",
+        "languages": ["typescript", "javascript"],
+    },
+    "flask": {
+        "git_url": "https://github.com/pallets/flask.git",
+        "ref": "3.1.2",
+        "paths": ["src/flask", "docs"],
+        "queries": "queries_flask",
+        "languages": ["python"],
     },
 }
 
@@ -102,7 +110,7 @@ def index_codebase(name: str, codebase_path: str, embed_client, model_key: str,
         project_path=codebase_path,
         project_db=db,
         embedding_client=embed_client,
-        languages=["typescript", "javascript"],
+        languages=config["languages"],
     )
     stats = indexer.index_project_sync()
 
@@ -154,10 +162,9 @@ def run_queries(queries, db, embed_client, reranker, rerank_pool: int = 40,
         # Use larger pool for code (more candidates needed), smaller for doc
         source_type = None
         pool = rerank_pool
-        if smart_routing:
-            if category == "code":
-                source_type = ["code"]
-                pool = max(rerank_pool, 100)
+        if smart_routing and category == "code":
+            source_type = ["code"]
+            pool = max(rerank_pool, 100)
 
         hits = hybrid_search(
             query_text, query_embedding, db,
@@ -326,11 +333,11 @@ def main():
             reranker = None
 
     # Ensure codebase
-    print(f"\n  Setting up codebase...")
+    print("\n  Setting up codebase...")
     codebase_path = ensure_codebase(args.codebase)
 
     # Index
-    print(f"  Setting up index...")
+    print("  Setting up index...")
     db = index_codebase(
         args.codebase, codebase_path, embed_client,
         model_key=args.model, reindex=args.reindex,

--- a/src/tessera/__main__.py
+++ b/src/tessera/__main__.py
@@ -213,6 +213,12 @@ def main() -> int:
         action="store_true",
         help="Disable cross-encoder reranking"
     )
+    serve_parser.add_argument(
+        "--tool-profile",
+        choices=["compact", "advanced"],
+        default="compact",
+        help="MCP tool surface: compact exposes explore only; advanced exposes all tools",
+    )
 
     args = parser.parse_args()
 
@@ -223,7 +229,7 @@ def main() -> int:
             args.project, args.global_db,
             args.embedding_endpoint, args.embedding_model,
             args.embedding_provider, args.reranking_model,
-            args.reranking_endpoint, args.no_reranking,
+            args.reranking_endpoint, args.no_reranking, args.tool_profile,
         ))
     else:
         parser.print_help()

--- a/src/tessera/indexer/_imports.py
+++ b/src/tessera/indexer/_imports.py
@@ -1,0 +1,132 @@
+"""Import-binding extraction for cross-file reference resolution."""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+
+@dataclass(frozen=True)
+class ImportBinding:
+    """A local import name and the in-project module that defines it."""
+
+    local_name: str
+    target_name: str
+    module_path: PurePosixPath
+    language: str
+
+
+_TYPESCRIPT_NAMED_IMPORT = re.compile(
+    r"\bimport\s+(?:type\s+)?\{(?P<names>[^}]+)\}\s+from\s*"
+    r"(?P<quote>['\"])(?P<module>[^'\"]+)(?P=quote)",
+    re.MULTILINE,
+)
+
+
+def extract_import_bindings(
+    file_path: str,
+    language: str,
+    source: str,
+) -> dict[str, ImportBinding]:
+    """Return local names that can be resolved to an in-project import target.
+
+    Only named imports are included. Namespace/default imports need receiver-aware
+    call extraction, and are intentionally left to the existing conservative
+    name-based fallback rather than being guessed here.
+    """
+    if language == "python":
+        return _extract_python_bindings(file_path, source)
+    if language in {"typescript", "javascript"}:
+        return _extract_typescript_bindings(file_path, language, source)
+    return {}
+
+
+def candidate_module_paths(binding: ImportBinding) -> set[str]:
+    """Return normalized indexed-file paths that may implement a binding."""
+    module = binding.module_path.as_posix()
+    if binding.language == "python":
+        return {f"{module}.py", f"{module}/__init__.py"}
+    return {
+        f"{module}.ts",
+        f"{module}.tsx",
+        f"{module}.js",
+        f"{module}.jsx",
+        f"{module}/index.ts",
+        f"{module}/index.tsx",
+        f"{module}/index.js",
+        f"{module}/index.jsx",
+    }
+
+
+def _extract_python_bindings(file_path: str, source: str) -> dict[str, ImportBinding]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    bindings: dict[str, ImportBinding] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module_path = _python_module_path(file_path, node.module, node.level)
+        if module_path is None:
+            continue
+        for imported in node.names:
+            if imported.name == "*":
+                continue
+            local_name = imported.asname or imported.name
+            bindings[local_name] = ImportBinding(
+                local_name=local_name,
+                target_name=imported.name,
+                module_path=module_path,
+                language="python",
+            )
+    return bindings
+
+
+def _python_module_path(
+    file_path: str,
+    module: str | None,
+    level: int,
+) -> PurePosixPath | None:
+    current_dir = PurePosixPath(file_path).parent
+    if level:
+        base = current_dir
+        for _ in range(level - 1):
+            base = base.parent
+        return base.joinpath(*(module.split(".") if module else ()))
+    if not module:
+        return None
+    return PurePosixPath(*module.split("."))
+
+
+def _extract_typescript_bindings(
+    file_path: str,
+    language: str,
+    source: str,
+) -> dict[str, ImportBinding]:
+    bindings: dict[str, ImportBinding] = {}
+    base_dir = PurePosixPath(file_path).parent
+    for match in _TYPESCRIPT_NAMED_IMPORT.finditer(source):
+        module = match.group("module")
+        if not module.startswith("."):
+            continue
+        module_path = base_dir.joinpath(module)
+        for raw_specifier in match.group("names").split(","):
+            specifier = raw_specifier.strip().removeprefix("type ").strip()
+            if not specifier:
+                continue
+            parts = re.split(r"\s+as\s+", specifier, maxsplit=1)
+            target_name = parts[0].strip()
+            local_name = parts[-1].strip()
+            if not target_name or not local_name:
+                continue
+            bindings[local_name] = ImportBinding(
+                local_name=local_name,
+                target_name=target_name,
+                module_path=module_path,
+                language=language,
+            )
+    return bindings

--- a/src/tessera/indexer/_imports.py
+++ b/src/tessera/indexer/_imports.py
@@ -16,6 +16,7 @@ class ImportBinding:
     target_name: str
     module_path: PurePosixPath
     language: str
+    is_module: bool = False
 
 
 _TYPESCRIPT_NAMED_IMPORT = re.compile(
@@ -32,9 +33,8 @@ def extract_import_bindings(
 ) -> dict[str, ImportBinding]:
     """Return local names that can be resolved to an in-project import target.
 
-    Only named imports are included. Namespace/default imports need receiver-aware
-    call extraction, and are intentionally left to the existing conservative
-    name-based fallback rather than being guessed here.
+    Named imports and Python module imports are included. Python module imports
+    are only used when a parser records a simple ``module.member()`` receiver.
     """
     if language == "python":
         return _extract_python_bindings(file_path, source)
@@ -68,21 +68,40 @@ def _extract_python_bindings(file_path: str, source: str) -> dict[str, ImportBin
 
     bindings: dict[str, ImportBinding] = {}
     for node in tree.body:
-        if not isinstance(node, ast.ImportFrom):
-            continue
-        module_path = _python_module_path(file_path, node.module, node.level)
-        if module_path is None:
-            continue
-        for imported in node.names:
-            if imported.name == "*":
+        if isinstance(node, ast.ImportFrom):
+            module_path = _python_module_path(file_path, node.module, node.level)
+            if module_path is None:
                 continue
-            local_name = imported.asname or imported.name
-            bindings[local_name] = ImportBinding(
-                local_name=local_name,
-                target_name=imported.name,
-                module_path=module_path,
-                language="python",
-            )
+            for imported in node.names:
+                if imported.name == "*":
+                    continue
+                local_name = imported.asname or imported.name
+                bindings[local_name] = ImportBinding(
+                    local_name=local_name,
+                    target_name=imported.name,
+                    module_path=module_path,
+                    language="python",
+                )
+        elif isinstance(node, ast.Import):
+            for imported in node.names:
+                # Without ``as``, ``import package.module`` binds ``package``.
+                # Do not pretend that it binds the nested module; that would
+                # turn uncertain resolution into a false-positive edge.
+                if imported.asname:
+                    local_name = imported.asname
+                    module_name = imported.name
+                elif "." not in imported.name:
+                    local_name = imported.name
+                    module_name = imported.name
+                else:
+                    continue
+                bindings[local_name] = ImportBinding(
+                    local_name=local_name,
+                    target_name="",
+                    module_path=PurePosixPath(*module_name.split(".")),
+                    language="python",
+                    is_module=True,
+                )
     return bindings
 
 

--- a/src/tessera/indexer/_pipeline.py
+++ b/src/tessera/indexer/_pipeline.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -955,7 +956,7 @@ class IndexerPipeline:
         # Query all unresolved refs for this project
         cursor = self.project_db.conn.execute(
             """
-            SELECT id, from_symbol_id, to_symbol_name, kind
+            SELECT id, from_symbol_id, to_symbol_name, kind, context
             FROM refs
             WHERE project_id = ? AND to_symbol_id IS NULL AND to_symbol_name IS NOT NULL
             """,
@@ -1049,50 +1050,94 @@ class IndexerPipeline:
         refs_to_update = []
         import_bindings_by_file: dict[int, dict[str, ImportBinding]] = {}
 
-        def resolve_import_binding(from_id: int, to_name: str) -> int | None:
-            """Resolve a local import alias to one target in its imported module."""
-            from_file_id = from_symbol_file.get(from_id)
-            if from_file_id is None:
-                return None
-            bindings = import_bindings_by_file.get(from_file_id)
-            if bindings is None:
-                from_path = file_id_to_path.get(from_file_id)
-                if not from_path:
-                    return None
-                source_path = Path(self.project_path) / from_path
-                try:
-                    source = source_path.read_text(encoding="utf-8", errors="replace")
-                except OSError:
-                    bindings = {}
-                else:
-                    suffix = source_path.suffix.lower()
-                    language = {
-                        ".py": "python",
-                        ".ts": "typescript",
-                        ".tsx": "typescript",
-                        ".js": "javascript",
-                        ".jsx": "javascript",
-                    }.get(suffix, "")
-                    bindings = extract_import_bindings(from_path, language, source)
-                import_bindings_by_file[from_file_id] = bindings
+        def load_import_bindings(file_id: int) -> dict[str, ImportBinding]:
+            """Read and cache import bindings for one indexed source file."""
+            bindings = import_bindings_by_file.get(file_id)
+            if bindings is not None:
+                return bindings
+            from_path = file_id_to_path.get(file_id)
+            if not from_path:
+                return {}
+            source_path = Path(self.project_path) / from_path
+            try:
+                source = source_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                bindings = {}
+            else:
+                suffix = source_path.suffix.lower()
+                language = {
+                    ".py": "python",
+                    ".ts": "typescript",
+                    ".tsx": "typescript",
+                    ".js": "javascript",
+                    ".jsx": "javascript",
+                }.get(suffix, "")
+                bindings = extract_import_bindings(from_path, language, source)
+            import_bindings_by_file[file_id] = bindings
+            return bindings
 
-            binding = bindings.get(to_name)
-            if binding is None:
-                return None
-            target_paths = candidate_module_paths(binding)
-            target_file_ids = {
-                file_id for file_id, path in file_id_to_path.items() if path in target_paths
-            }
+        def target_file_ids(binding: ImportBinding) -> set[int]:
+            paths = candidate_module_paths(binding)
+            return {file_id for file_id, path in file_id_to_path.items() if path in paths}
+
+        def direct_symbol(file_ids: set[int], symbol_name: str) -> int | None:
             candidates = [
                 candidate
-                for candidate in name_to_candidates.get(binding.target_name, [])
-                if candidate[2] in target_file_ids
+                for candidate in name_to_candidates.get(symbol_name, [])
+                if candidate[2] in file_ids
             ]
             if not candidates:
                 return None
             best_priority = min(candidate[1] for candidate in candidates)
-            best_candidates = [candidate for candidate in candidates if candidate[1] == best_priority]
-            return best_candidates[0][0] if len(best_candidates) == 1 else None
+            best = [candidate for candidate in candidates if candidate[1] == best_priority]
+            return best[0][0] if len(best) == 1 else None
+
+        def resolve_export(
+            file_ids: set[int],
+            export_name: str,
+            seen: set[tuple[int, str]],
+        ) -> int | None:
+            """Resolve a module export, following conservative named re-exports."""
+            direct = direct_symbol(file_ids, export_name)
+            if direct is not None:
+                return direct
+            resolved: set[int] = set()
+            for file_id in file_ids:
+                key = (file_id, export_name)
+                if key in seen:
+                    continue
+                forwarded = load_import_bindings(file_id).get(export_name)
+                if forwarded is None or forwarded.is_module:
+                    continue
+                target = resolve_export(
+                    target_file_ids(forwarded), forwarded.target_name, seen | {key}
+                )
+                if target is not None:
+                    resolved.add(target)
+            return resolved.pop() if len(resolved) == 1 else None
+
+        def module_receiver(context: str, to_name: str) -> str | None:
+            """Return the receiver only for a simple ``module.member()`` expression."""
+            match = re.fullmatch(r"([A-Za-z_]\w*)\.([A-Za-z_]\w*)", context.strip())
+            if match and match.group(2) == to_name:
+                return match.group(1)
+            return None
+
+        def resolve_import_binding(from_id: int, to_name: str, context: str) -> int | None:
+            """Resolve a local import alias to one target in its imported module."""
+            from_file_id = from_symbol_file.get(from_id)
+            if from_file_id is None:
+                return None
+            bindings = load_import_bindings(from_file_id)
+            binding = bindings.get(to_name)
+            if binding is not None and not binding.is_module:
+                return resolve_export(target_file_ids(binding), binding.target_name, set())
+
+            receiver = module_receiver(context, to_name)
+            module_binding = bindings.get(receiver) if receiver else None
+            if module_binding is not None and module_binding.is_module:
+                return resolve_export(target_file_ids(module_binding), to_name, set())
+            return None
 
         for ref in unresolved_refs:
             to_name = ref['to_symbol_name']
@@ -1104,7 +1149,7 @@ class IndexerPipeline:
 
             # 1. Import-aware resolution. This is more specific than the
             # project-wide name fallback and therefore wins for aliases.
-            resolved_id = resolve_import_binding(from_id, to_name)
+            resolved_id = resolve_import_binding(from_id, to_name, ref['context'] or "")
             if resolved_id is not None:
                 resolution_type = "import"
 

--- a/src/tessera/indexer/_pipeline.py
+++ b/src/tessera/indexer/_pipeline.py
@@ -25,10 +25,10 @@ from ..document import (
     chunk_xml,
     chunk_yaml,
 )
-from ..markdown_chunker import chunk_markdown_breakpoint
 from ..embeddings import EmbeddingClient, EmbeddingUnavailableError, FastembedClient
 from ..hooks import AFTER_INDEX_FILE, BEFORE_INDEX_FILE, EMBEDDING_TEXTS, get_hooks, setup_model_hooks
 from ..ignore import IgnoreFilter
+from ..markdown_chunker import chunk_markdown_breakpoint
 from ..model_profiles import ModelProfile, resolve_profile
 from ..parser import detect_language, parse_and_extract
 from ..search import hybrid_search
@@ -39,6 +39,7 @@ from ._helpers import (
     _detect_package_name,
     compute_parser_digest,
 )
+from ._imports import ImportBinding, candidate_module_paths, extract_import_bindings
 
 logger = logging.getLogger(__name__)
 
@@ -944,11 +945,11 @@ class IndexerPipeline:
 
         Returns:
             Stats dict with keys: total_unresolved, resolved_strict,
-            resolved_proximity, resolved_suffix, ambiguous_dropped,
+            resolved_import, resolved_proximity, resolved_suffix, ambiguous_dropped,
             no_candidate, edges_created.
         """
         empty_stats: dict[str, int] = {
-            "total_unresolved": 0, "resolved_strict": 0,
+            "total_unresolved": 0, "resolved_strict": 0, "resolved_import": 0,
             "resolved_proximity": 0, "resolved_suffix": 0,
             "ambiguous_dropped": 0, "no_candidate": 0, "edges_created": 0,
         }
@@ -1050,6 +1051,52 @@ class IndexerPipeline:
         # Resolve refs and prepare edges to insert
         edges_to_insert = []
         refs_to_update = []
+        import_bindings_by_file: dict[int, dict[str, ImportBinding]] = {}
+
+        def resolve_import_binding(from_id: int, to_name: str) -> int | None:
+            """Resolve a local import alias to one target in its imported module."""
+            from_file_id = from_symbol_file.get(from_id)
+            if from_file_id is None:
+                return None
+            bindings = import_bindings_by_file.get(from_file_id)
+            if bindings is None:
+                from_path = file_id_to_path.get(from_file_id)
+                if not from_path:
+                    return None
+                source_path = Path(self.project_path) / from_path
+                try:
+                    source = source_path.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    bindings = {}
+                else:
+                    suffix = source_path.suffix.lower()
+                    language = {
+                        ".py": "python",
+                        ".ts": "typescript",
+                        ".tsx": "typescript",
+                        ".js": "javascript",
+                        ".jsx": "javascript",
+                    }.get(suffix, "")
+                    bindings = extract_import_bindings(from_path, language, source)
+                import_bindings_by_file[from_file_id] = bindings
+
+            binding = bindings.get(to_name)
+            if binding is None:
+                return None
+            target_paths = candidate_module_paths(binding)
+            target_file_ids = {
+                file_id for file_id, path in file_id_to_path.items() if path in target_paths
+            }
+            candidates = [
+                candidate
+                for candidate in name_to_candidates.get(binding.target_name, [])
+                if candidate[2] in target_file_ids
+            ]
+            if not candidates:
+                return None
+            best_priority = min(candidate[1] for candidate in candidates)
+            best_candidates = [candidate for candidate in candidates if candidate[1] == best_priority]
+            return best_candidates[0][0] if len(best_candidates) == 1 else None
 
         for ref in unresolved_refs:
             to_name = ref['to_symbol_name']
@@ -1059,12 +1106,18 @@ class IndexerPipeline:
             resolved_id = None
             resolution_type = None
 
-            # 1. Strict match (unambiguous name)
-            if to_name in name_to_symbol:
+            # 1. Import-aware resolution. This is more specific than the
+            # project-wide name fallback and therefore wins for aliases.
+            resolved_id = resolve_import_binding(from_id, to_name)
+            if resolved_id is not None:
+                resolution_type = "import"
+
+            # 2. Strict match (unambiguous name)
+            elif to_name in name_to_symbol:
                 resolved_id = name_to_symbol[to_name]
                 resolution_type = "strict"
 
-            # 2. Ambiguous match — use file-proximity tiebreak
+            # 3. Ambiguous match — use file-proximity tiebreak
             elif to_name in ambiguous_names:
                 from_file_id = from_symbol_file.get(from_id)
                 if from_file_id:
@@ -1085,7 +1138,7 @@ class IndexerPipeline:
                 else:
                     stats["ambiguous_dropped"] += 1
 
-            # 3. Suffix match for namespaced symbols
+            # 4. Suffix match for namespaced symbols
             elif to_name in suffix_candidates:
                 suffix_cands = suffix_candidates[to_name]
                 suffix_cands_sorted = sorted(suffix_cands, key=lambda x: x[1])
@@ -1143,10 +1196,10 @@ class IndexerPipeline:
 
         stats["edges_created"] = len(edges_to_insert)
         logger.info(
-            "Cross-file edge resolution: %d unresolved → %d strict, %d proximity, "
+            "Cross-file edge resolution: %d unresolved → %d strict, %d import, %d proximity, "
             "%d suffix, %d ambiguous, %d no-candidate (%d edges created)",
             stats["total_unresolved"], stats["resolved_strict"],
-            stats["resolved_proximity"], stats["resolved_suffix"],
+            stats["resolved_import"], stats["resolved_proximity"], stats["resolved_suffix"],
             stats["ambiguous_dropped"], stats["no_candidate"],
             stats["edges_created"],
         )

--- a/src/tessera/indexer/_pipeline.py
+++ b/src/tessera/indexer/_pipeline.py
@@ -85,6 +85,12 @@ class IndexerPipeline:
         self.model_profile = model_profile
         setup_model_hooks(model_profile)
 
+    def _ensure_project_id(self) -> int:
+        """Return the registered project ID, registering standalone projects on demand."""
+        if self.project_id is None:
+            return self.register()
+        return self.project_id
+
     def _track_embedding_dim(self, dim: int) -> None:
         """Store embedding dimension on first call, warn on mismatch."""
         stored = self.project_db.get_meta("embedding_dim")
@@ -254,7 +260,7 @@ class IndexerPipeline:
 
         # Try to get since_commit from GlobalDB if not provided
         if since_commit is None and self.global_db:
-            project = self.global_db.get_project(self.project_id)
+            project = self.global_db.get_project(self._ensure_project_id())
             if project:
                 since_commit = project.get("last_indexed_commit")
 
@@ -292,7 +298,7 @@ class IndexerPipeline:
         # Update last indexed commit
         head = self._get_git_head()
         if head and self.global_db:
-            self.global_db.update_last_indexed_commit(self.project_id, head)
+            self.global_db.update_last_indexed_commit(self._ensure_project_id(), head)
 
         return stats
 
@@ -320,6 +326,8 @@ class IndexerPipeline:
                         "pymupdf4llm not installed. Install with: pip install pymupdf4llm"
                     ) from None
                 markdown_text = pymupdf4llm.to_markdown(file_path)
+                if not isinstance(markdown_text, str):
+                    markdown_text = "\n\n".join(page.get("text", "") for page in markdown_text)
                 chunks = chunk_markdown_breakpoint(markdown_text)
             elif file_path.endswith(('.md', '.mdx')):
                 content = Path(file_path).read_text(encoding='utf-8', errors='replace')
@@ -343,25 +351,21 @@ class IndexerPipeline:
             # Compute file hash
             file_hash = self._file_hash(file_path)
 
+            existing = self.project_db.get_file(path=rel_path)
+            if (
+                existing
+                and existing.get('index_status') == 'indexed'
+                and existing.get('hash') == file_hash
+            ):
+                return {'status': 'skipped', 'reason': 'unchanged'}
+
             # Upsert file record (language='document')
             file_id = self.project_db.upsert_file(
-                project_id=self.project_id,
+                project_id=self._ensure_project_id(),
                 path=rel_path,
                 language='document',
                 file_hash=file_hash
             )
-
-            # Check if file changed
-            old_hash = self.project_db.get_old_hash() if hasattr(self.project_db, 'get_old_hash') else None
-            existing = self.project_db.get_file(file_id=file_id)
-
-            if (
-                existing
-                and existing.get('index_status') == 'indexed'
-                and old_hash is not None
-                and old_hash == file_hash
-            ):
-                return {'status': 'skipped', 'reason': 'unchanged'}
 
             # Clear old data and mark as pending
             with self.project_db.conn:
@@ -423,7 +427,7 @@ class IndexerPipeline:
             logger.error(f"Document extraction error in {file_path}: {e}")
             try:
                 file_id = self.project_db.upsert_file(
-                    project_id=self.project_id,
+                    project_id=self._ensure_project_id(),
                     path=rel_path,
                     language='document',
                     file_hash=self._file_hash(file_path)
@@ -436,7 +440,7 @@ class IndexerPipeline:
             logger.error(f"Failed to index document {file_path}: {e}")
             try:
                 file_id = self.project_db.upsert_file(
-                    project_id=self.project_id,
+                    project_id=self._ensure_project_id(),
                     path=rel_path,
                     language='document',
                     file_hash=self._file_hash(file_path)
@@ -471,23 +475,20 @@ class IndexerPipeline:
 
             file_hash = self._file_hash(file_path)
 
+            existing = self.project_db.get_file(path=rel_path)
+            if (
+                existing
+                and existing.get('index_status') == 'indexed'
+                and existing.get('hash') == file_hash
+            ):
+                return {'status': 'skipped', 'reason': 'unchanged'}
+
             file_id = self.project_db.upsert_file(
-                project_id=self.project_id,
+                project_id=self._ensure_project_id(),
                 path=rel_path,
                 language='asset',
                 file_hash=file_hash,
             )
-
-            old_hash = self.project_db.get_old_hash() if hasattr(self.project_db, 'get_old_hash') else None
-            existing = self.project_db.get_file(file_id=file_id)
-
-            if (
-                existing
-                and existing.get('index_status') == 'indexed'
-                and old_hash is not None
-                and old_hash == file_hash
-            ):
-                return {'status': 'skipped', 'reason': 'unchanged'}
 
             dimensions = metadata['dimensions']
             key_path = f"{dimensions['width']}x{dimensions['height']}" if dimensions else None
@@ -531,7 +532,7 @@ class IndexerPipeline:
             logger.error("Failed to index asset %s: %s", file_path, e)
             try:
                 file_id = self.project_db.upsert_file(
-                    project_id=self.project_id,
+                    project_id=self._ensure_project_id(),
                     path=rel_path,
                     language='asset',
                     file_hash=self._file_hash(file_path),
@@ -601,6 +602,7 @@ class IndexerPipeline:
             Status dict with 'status' and optional 'reason' or metrics
         """
         await self.hooks.do_action(BEFORE_INDEX_FILE, file_path)
+        self._ensure_project_id()
 
         # Route asset files BEFORE document check (some assets like .svg are also documents)
         is_svg = file_path.lower().endswith('.svg')
@@ -631,28 +633,22 @@ class IndexerPipeline:
         # Compute file hash
         file_hash = self._file_hash(file_path)
 
-        # Upsert file record (returns file_id, may be existing file)
-        file_id = self.project_db.upsert_file(
-            project_id=self.project_id,
-            path=rel_path,
-            language=language,
-            file_hash=file_hash
-        )
-
-        # Check if file changed - get the old hash from before upsert
-        old_hash = self.project_db.get_old_hash() if hasattr(self.project_db, 'get_old_hash') else None
-        existing = self.project_db.get_file(file_id=file_id)
-
-        # If file was already indexed with the same hash, skip it
-        # old_hash is not None means this was an existing file
+        existing = self.project_db.get_file(path=rel_path)
         if (
             not force
             and existing
             and existing.get('index_status') == 'indexed'
-            and old_hash is not None  # This was an existing file
-            and old_hash == file_hash  # And the hash is the same
+            and existing.get('hash') == file_hash
         ):
             return {'status': 'skipped', 'reason': 'unchanged'}
+
+        # Upsert file record (returns file_id, may be existing file)
+        file_id = self.project_db.upsert_file(
+            project_id=self._ensure_project_id(),
+            path=rel_path,
+            language=language,
+            file_hash=file_hash
+        )
 
         # Parse FIRST (before clearing old data — if parsing fails, old data preserved)
         try:
@@ -845,7 +841,7 @@ class IndexerPipeline:
         # Create job record for tracking
         job_id = None
         if self.global_db:
-            job_id = self.global_db.create_job(self.project_id)
+            job_id = self.global_db.create_job(self._ensure_project_id())
             self.global_db.start_job(job_id)
 
         try:
@@ -893,7 +889,7 @@ class IndexerPipeline:
             # Store last indexed commit for future incremental reindexing
             head = self._get_git_head()
             if head and self.global_db:
-                self.global_db.update_last_indexed_commit(self.project_id, head)
+                self.global_db.update_last_indexed_commit(self._ensure_project_id(), head)
 
             # Store parser digest so the server can detect stale indexes
             self.project_db.set_meta("parser_digest", compute_parser_digest())
@@ -1227,4 +1223,4 @@ class IndexerPipeline:
             except EmbeddingUnavailableError:
                 pass
 
-        return hybrid_search(query, query_embedding, self.project_db, limit)
+        return hybrid_search(query, query_embedding, self.project_db, graph=None, limit=limit)

--- a/src/tessera/parser/languages/python.py
+++ b/src/tessera/parser/languages/python.py
@@ -163,6 +163,7 @@ class PythonExtractor(LanguageExtractor):
                                     to_symbol=method_name,
                                     kind="calls",
                                     line=node.start_point[0] + 1,
+                                    context=func_node.text.decode("utf-8"),
                                 )
                                 references.append(ref)
                             func_name = None  # Don't process again below

--- a/src/tessera/search.py
+++ b/src/tessera/search.py
@@ -689,7 +689,7 @@ def hybrid_search(
         source_type: Optional list of source types to filter by (e.g., ['code', 'markdown'])
         search_types: Which search lists to run. None = parse from query prefix.
         advanced_fts: If True, allow FTS5 operators (phrases, NOT, *, NEAR).
-        filename_boost: Boost RRF score per query-token/filename overlap (0.003 recommended)
+        filename_boost: Optional post-merge score per query-token/filename overlap
         file_dedup: Keep only the best-scoring chunk per file
     """
     # Parse structured query prefix if search_types not explicitly provided

--- a/src/tessera/search.py
+++ b/src/tessera/search.py
@@ -22,8 +22,8 @@ import json
 import logging
 import os
 import re
-from enum import StrEnum
 from collections.abc import Callable
+from enum import StrEnum
 from typing import Optional
 
 import faiss
@@ -93,6 +93,10 @@ def normalize_bm25_score(raw_score: float) -> float:
 # if >5% of queries return insufficient results (CTO Condition C4).
 SEMANTIC_SEARCH_OVER_FETCH_MULTIPLIER = 3
 
+# File-level results need a larger chunk candidate pool before deduplication;
+# otherwise one long file can consume the entire requested limit.
+FILE_DEDUP_OVER_FETCH_MULTIPLIER = 5
+
 # BM25 short-circuit thresholds: skip semantic/PPR when keyword match is very confident.
 # Known failure mode: in corpora with many similar symbol names (e.g., parseUserInput
 # vs parseUserConfig), the gap can be wide while the top hit is still semantically
@@ -136,11 +140,32 @@ def bm25_strong_signal_check(
     return (top_score - second_score) >= gap
 
 
+def _dedupe_ranked_by_file(items: list[dict], db) -> list[dict]:
+    """Keep the highest-ranked item for each source file."""
+    seen_files: set[str] = set()
+    deduped: list[dict] = []
+    for item in items:
+        chunk_id = item["id"]
+        try:
+            meta = db.get_chunk(chunk_id)
+            file_path = meta.get("file_path", "")
+            if not file_path and meta.get("file_id"):
+                file_rec = db.get_file(file_id=meta["file_id"])
+                if file_rec:
+                    file_path = file_rec.get("path", "")
+        except Exception:
+            file_path = ""
+        if file_path not in seen_files:
+            seen_files.add(file_path)
+            deduped.append(item)
+    return deduped
+
+
 def _find_best_match_line(
     lines: list[str],
     query: str,
-    query_embedding: Optional[np.ndarray] = None,
-    embed_fn: Optional[Callable[..., list]] = None,
+    query_embedding: np.ndarray | None = None,
+    embed_fn: Callable[..., list] | None = None,
 ) -> int:
     """Find the line with the highest relevance to the query.
 
@@ -172,7 +197,7 @@ def _find_best_match_line(
 def _semantic_best_line(
     lines: list[str],
     query_embedding: np.ndarray,
-    embed_fn: callable,
+    embed_fn: Callable[..., list],
     window_size: int = 3,
 ) -> int:
     """Score sliding windows by cosine similarity, return center line of best."""
@@ -220,8 +245,8 @@ def extract_snippet(
     chunk_start_line: int = 0,
     mode: str = "lines",
     max_depth: int | None = None,
-    query_embedding: Optional[np.ndarray] = None,
-    embed_fn: Optional[Callable[..., list]] = None,
+    query_embedding: np.ndarray | None = None,
+    embed_fn: Callable[..., list] | None = None,
 ) -> dict:
     """Extract best-matching snippet from chunk content with optional ancestry.
 
@@ -700,8 +725,14 @@ def hybrid_search(
         try:
             kw_query = expanded_query if query_expansion else query
             kw_advanced = True if query_expansion else advanced_fts
+            keyword_limit = (
+                limit * FILE_DEDUP_OVER_FETCH_MULTIPLIER if file_dedup else limit
+            )
             keyword_results = db.keyword_search(
-                kw_query, limit=limit, source_type=source_type, advanced_fts=kw_advanced
+                kw_query,
+                limit=keyword_limit,
+                source_type=source_type,
+                advanced_fts=kw_advanced,
             )
             if keyword_results:
                 ranked_lists.append(keyword_results)
@@ -711,10 +742,25 @@ def hybrid_search(
 
     # 1b. BM25 strong-signal short-circuit: skip expensive operations when
     # keyword match is very high confidence (top score >= 0.85 with >= 0.15 gap)
-    if keyword_results and bm25_strong_signal_check(keyword_results):
+    strong_keyword_signal = bool(
+        keyword_results and bm25_strong_signal_check(keyword_results)
+    )
+    if strong_keyword_signal and file_dedup:
+        unique_keyword_results = _dedupe_ranked_by_file(keyword_results, db)
+        if len(unique_keyword_results) < limit:
+            logger.debug(
+                "BM25 short-circuit skipped: %d unique files for requested limit %d",
+                len(unique_keyword_results),
+                limit,
+            )
+            strong_keyword_signal = False
+
+    if strong_keyword_signal:
         logger.debug("BM25 short-circuit: strong signal, skipping semantic/PPR")
         weights = [effective_weights.get("keyword", 1.0)]
         merged = weighted_rrf_merge(ranked_lists, weights=weights)
+        if file_dedup:
+            merged = _dedupe_ranked_by_file(merged, db)
         results = []
         for item in merged[:limit]:
             chunk_id = item["id"]
@@ -774,10 +820,13 @@ def hybrid_search(
                 chunk_ids, embedding_vectors = all_embeddings
                 if retrieval_pool:
                     fetch_limit = retrieval_pool
-                elif source_type:
-                    fetch_limit = limit * SEMANTIC_SEARCH_OVER_FETCH_MULTIPLIER
                 else:
-                    fetch_limit = limit
+                    multipliers = [1]
+                    if source_type:
+                        multipliers.append(SEMANTIC_SEARCH_OVER_FETCH_MULTIPLIER)
+                    if file_dedup:
+                        multipliers.append(FILE_DEDUP_OVER_FETCH_MULTIPLIER)
+                    fetch_limit = limit * max(multipliers)
                 semantic_results = cosine_search(
                     query_embedding,
                     chunk_ids,
@@ -791,7 +840,12 @@ def hybrid_search(
                         chunk = db.get_chunk(result["id"])
                         if chunk and (chunk.get("source_type") or "code") in source_type:
                             filtered.append(result)
-                    semantic_results = filtered[:limit]
+                    filtered_limit = (
+                        limit * FILE_DEDUP_OVER_FETCH_MULTIPLIER
+                        if file_dedup
+                        else limit
+                    )
+                    semantic_results = filtered[:filtered_limit]
                 if semantic_results:
                     ranked_lists.append(semantic_results)
                     list_labels.append("semantic")
@@ -928,23 +982,7 @@ def hybrid_search(
 
     # 4d. File-level dedup — keep only the best-scoring chunk per file
     if file_dedup:
-        seen_files = set()
-        deduped = []
-        for item in merged:
-            chunk_id = item["id"]
-            try:
-                meta = db.get_chunk(chunk_id)
-                file_path = meta.get("file_path", "")
-                if not file_path and meta.get("file_id"):
-                    file_rec = db.get_file(file_id=meta["file_id"])
-                    if file_rec:
-                        file_path = file_rec.get("path", "")
-            except Exception:
-                file_path = ""
-            if file_path not in seen_files:
-                seen_files.add(file_path)
-                deduped.append(item)
-        merged = deduped
+        merged = _dedupe_ranked_by_file(merged, db)
 
     # 5. Enrich with chunk metadata
     results = []

--- a/src/tessera/search.py
+++ b/src/tessera/search.py
@@ -93,7 +93,13 @@ def normalize_bm25_score(raw_score: float) -> float:
 # if >5% of queries return insufficient results (CTO Condition C4).
 SEMANTIC_SEARCH_OVER_FETCH_MULTIPLIER = 3
 
-# BM25 short-circuit thresholds: skip semantic/PPR when keyword match is very confident
+# BM25 short-circuit thresholds: skip semantic/PPR when keyword match is very confident.
+# Known failure mode: in corpora with many similar symbol names (e.g., parseUserInput
+# vs parseUserConfig), the gap can be wide while the top hit is still semantically
+# wrong for the query. Query expansion (camelCase/hyphen variants) reduces but does
+# not eliminate this — if both symbols are common, expansion just makes BM25 more
+# confident in the wrong answer. RRF cannot rescue queries that are lexically
+# ambiguous; this is a precision/latency tradeoff, not a correctness guarantee.
 BM25_STRONG_SIGNAL_THRESHOLD = 0.85
 BM25_STRONG_SIGNAL_GAP = 0.15
 

--- a/src/tessera/server/_app.py
+++ b/src/tessera/server/_app.py
@@ -23,6 +23,7 @@ def create_server(
     reranking_model: str | None = None,
     reranking_endpoint: str | None = None,
     no_reranking: bool = False,
+    tool_profile: str = "advanced",
 ) -> FastMCP:
     """Create and configure the MCP server (synchronous, for tests and CLI).
 
@@ -34,7 +35,7 @@ def create_server(
         embedding_provider, reranking_model, reranking_endpoint, no_reranking,
     )
     mcp = FastMCP("tessera")
-    register_tools(mcp)
+    register_tools(mcp, tool_profile)
     return mcp
 
 
@@ -76,8 +77,9 @@ def _create_hmr_app() -> FastMCP:
             if not bg_task.done():
                 bg_task.cancel()
 
+    tool_profile = os.environ.get("TESSERA_TOOL_PROFILE", "compact")
     mcp = FastMCP("tessera", lifespan=_lifespan)
-    register_tools(mcp)
+    register_tools(mcp, tool_profile)
     return mcp
 
 
@@ -90,6 +92,7 @@ async def run_server(
     reranking_model: str | None = None,
     reranking_endpoint: str | None = None,
     no_reranking: bool = False,
+    tool_profile: str = "compact",
 ) -> int:
     """Run the MCP server on stdio transport."""
     if not global_db_path:
@@ -99,6 +102,7 @@ async def run_server(
     mcp = create_server(
         project_path, global_db_path, embedding_endpoint, embedding_model,
         embedding_provider, reranking_model, reranking_endpoint, no_reranking,
+        tool_profile,
     )
 
     try:

--- a/src/tessera/server/tools/__init__.py
+++ b/src/tessera/server/tools/__init__.py
@@ -6,13 +6,19 @@ from ._admin import register_admin_tools
 from ._analysis import register_analysis_tools
 from ._collections import register_collection_tools
 from ._events import register_event_tools
+from ._explore import register_explore_tools
 from ._scope import register_scope_tools
 from ._search import register_search_tools
 from ._symbols import register_symbol_tools
 
 
-def register_tools(mcp: FastMCP) -> None:
-    """Register all MCP tool handlers on the server instance."""
+def register_tools(mcp: FastMCP, tool_profile: str = "advanced") -> None:
+    """Register the compact or advanced MCP tool profile."""
+    register_explore_tools(mcp)
+    if tool_profile == "compact":
+        return
+    if tool_profile != "advanced":
+        raise ValueError("tool_profile must be 'compact' or 'advanced'")
     register_search_tools(mcp)
     register_symbol_tools(mcp)
     register_analysis_tools(mcp)

--- a/src/tessera/server/tools/_explore.py
+++ b/src/tessera/server/tools/_explore.py
@@ -1,0 +1,194 @@
+"""Compact, task-oriented MCP exploration tool."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any
+
+from fastmcp import FastMCP
+
+from ...embeddings import EmbeddingUnavailableError
+from ...search import extract_snippet, hybrid_search
+from .._state import _check_session, _get_project_dbs, _log_audit
+
+logger = logging.getLogger("tessera.server")
+
+_MAX_RESULTS = 10
+_MAX_FILES = 3
+_MAX_FILE_SYMBOLS = 12
+_MAX_GRAPH_SYMBOLS = 3
+_MAX_GRAPH_EDGES = 8
+
+
+def _file_outline(db: Any, file_id: int) -> list[dict[str, Any]]:
+    """Return a bounded structural outline for one indexed file."""
+    rows = db.conn.execute(
+        """
+        SELECT name, kind, line, scope, signature
+        FROM symbols WHERE file_id = ? ORDER BY line LIMIT ?
+        """,
+        (file_id, _MAX_FILE_SYMBOLS),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _symbol_graph(db: Any, query: str) -> list[dict[str, Any]]:
+    """Return small, exact-name graph slices for identifier-like query tokens."""
+    graph: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    for token in re.findall(r"[A-Za-z_]\w+", query):
+        if token in seen_names:
+            continue
+        seen_names.add(token)
+        matches = db.lookup_symbols(token)
+        exact = next((symbol for symbol in matches if symbol.get("name") == token), None)
+        if exact is None:
+            continue
+        outgoing = db.get_refs(symbol_id=exact["id"])[:_MAX_GRAPH_EDGES]
+        callers = db.get_callers(symbol_name=token)[:_MAX_GRAPH_EDGES]
+        graph.append({
+            "symbol": {
+                "name": exact["name"],
+                "kind": exact["kind"],
+                "file_id": exact["file_id"],
+                "line": exact["line"],
+                "signature": exact.get("signature", ""),
+            },
+            "outgoing": [
+                {
+                    "symbol": ref.get("to_symbol_name", ""),
+                    "kind": ref.get("kind", ""),
+                    "line": ref.get("line", 0),
+                }
+                for ref in outgoing
+            ],
+            "callers": [
+                {
+                    "name": caller.get("name", ""),
+                    "kind": caller.get("kind", ""),
+                    "file_id": caller.get("file_id"),
+                    "line": caller.get("line", 0),
+                }
+                for caller in callers
+            ],
+        })
+        if len(graph) == _MAX_GRAPH_SYMBOLS:
+            break
+    return graph
+
+
+def register_explore_tools(mcp: FastMCP) -> None:
+    """Register the compact default exploration entry point."""
+
+    @mcp.tool()
+    async def explore(query: str, max_results: int = 5, session_id: str = "") -> str:
+        """Investigate a codebase question in one bounded, agent-ready context pack.
+
+        Use this as the default starting point for finding an implementation,
+        understanding how a feature works, or assessing a likely change area.
+        It combines hybrid code search with per-file symbol outlines and exact
+        reference/caller slices when identifiers in the query match symbols.
+
+        Args:
+            query: Natural-language question or identifier to investigate.
+            max_results: Maximum ranked code results (1-10; default 5).
+            session_id: Optional scope-gated session token.
+        """
+        from .._state import _embedding_client
+
+        scope, err = _check_session({"session_id": session_id}, "project")
+        if err:
+            return err
+        agent_id = scope.agent_id if scope else "dev"
+        dbs = _get_project_dbs(scope)
+        if not dbs:
+            _log_audit("explore", 0, agent_id=agent_id)
+            return "Error: No accessible projects"
+
+        limit = max(1, min(max_results, _MAX_RESULTS))
+        query_embedding = None
+        if _embedding_client:
+            try:
+                import numpy as np
+
+                raw = await asyncio.to_thread(_embedding_client.embed_query, query)
+                query_embedding = np.array(raw, dtype=np.float32)
+            except EmbeddingUnavailableError:
+                logger.debug("Embedding endpoint unavailable; explore is using keyword retrieval")
+
+        def collect_project(project_id: int, project_name: str, db: Any) -> dict[str, Any]:
+            results = hybrid_search(
+                query, query_embedding, db, None, limit,
+                source_type=["code"], file_dedup=True,
+            )
+            packed_results = []
+            files: list[dict[str, Any]] = []
+            seen_file_ids: set[int] = set()
+            for result in results:
+                snippet = extract_snippet(result.get("content", ""), query)
+                packed_results.append({
+                    "project_id": project_id,
+                    "project_name": project_name,
+                    "path": result.get("file_path", ""),
+                    "start_line": result.get("start_line", 0) + 1,
+                    "end_line": result.get("end_line", 0) + 1,
+                    "score": round(float(result.get("score", 0.0)), 6),
+                    "snippet": snippet.get("snippet", ""),
+                    "source_type": result.get("source_type", "code"),
+                })
+                file_id = result.get("file_id")
+                if not file_id or file_id in seen_file_ids or len(files) >= _MAX_FILES:
+                    continue
+                seen_file_ids.add(file_id)
+                file_info = db.get_file(file_id=file_id)
+                if file_info:
+                    files.append({
+                        "project_id": project_id,
+                        "project_name": project_name,
+                        "path": file_info.get("path", ""),
+                        "language": file_info.get("language", ""),
+                        "symbols": _file_outline(db, file_id),
+                    })
+            return {
+                "results": packed_results,
+                "files": files,
+                "symbols": _symbol_graph(db, query),
+            }
+
+        try:
+            tasks = [
+                asyncio.to_thread(collect_project, project_id, project_name, db)
+                for project_id, project_name, db in dbs
+            ]
+            project_packs = await asyncio.gather(*tasks, return_exceptions=True)
+            results: list[dict[str, Any]] = []
+            files: list[dict[str, Any]] = []
+            symbols: list[dict[str, Any]] = []
+            for pack in project_packs:
+                if isinstance(pack, BaseException):
+                    logger.warning("Explore query failed for a project: %s", pack)
+                    continue
+                results.extend(pack["results"])
+                files.extend(pack["files"])
+                symbols.extend(pack["symbols"])
+
+            results.sort(key=lambda item: item["score"], reverse=True)
+            payload = {
+                "query": query,
+                "results": results[:limit],
+                "files": files[:_MAX_FILES],
+                "symbols": symbols[:_MAX_GRAPH_SYMBOLS],
+                "next_steps": [
+                    "Start with the highest-ranked snippet and file outline.",
+                    "Use the advanced tool profile only when you need deeper, targeted analysis.",
+                ],
+            }
+            _log_audit("explore", len(payload["results"]), agent_id=agent_id)
+            return json.dumps(payload, indent=2)
+        except Exception as exc:
+            logger.exception("Explore tool error")
+            _log_audit("explore", 0, agent_id=agent_id)
+            return f"Error exploring codebase: {exc}"

--- a/tests/integration/test_cross_file_edges.py
+++ b/tests/integration/test_cross_file_edges.py
@@ -567,7 +567,7 @@ class TestCrossFileEdgeResolution:
         stats = indexer._resolve_cross_file_edges()
 
         expected_keys = {
-            "total_unresolved", "resolved_strict", "resolved_proximity",
+            "total_unresolved", "resolved_strict", "resolved_import", "resolved_proximity",
             "resolved_suffix", "ambiguous_dropped", "no_candidate", "edges_created",
         }
         assert set(stats.keys()) == expected_keys

--- a/tests/integration/test_explore_tool.py
+++ b/tests/integration/test_explore_tool.py
@@ -1,0 +1,38 @@
+"""End-to-end coverage for the compact MCP explore tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastmcp import Client
+
+from tessera.indexer import IndexerPipeline
+from tessera.server import create_server
+
+
+async def test_explore_returns_bounded_code_and_graph_context(tmp_path: Path) -> None:
+    (tmp_path / "service.py").write_text(
+        "def run() -> str:\n"
+        "    return 'service'\n"
+    )
+    (tmp_path / "caller.py").write_text(
+        "from service import run\n\n"
+        "def handle_request() -> str:\n"
+        "    return run()\n"
+    )
+    await IndexerPipeline(str(tmp_path), languages=["python"]).index_project()
+
+    server = create_server(
+        str(tmp_path), str(tmp_path / "global.db"), tool_profile="compact"
+    )
+    async with Client(server) as client:
+        result = await client.call_tool("explore", {"query": "run service", "max_results": 3})
+
+    payload = json.loads(result.content[0].text)
+    assert payload["query"] == "run service"
+    assert 1 <= len(payload["results"]) <= 3
+    assert any(item["path"] == "service.py" for item in payload["results"])
+    assert payload["symbols"]
+    assert payload["files"]
+    assert "next_steps" in payload

--- a/tests/integration/test_import_alias_resolution.py
+++ b/tests/integration/test_import_alias_resolution.py
@@ -59,3 +59,56 @@ def test_import_alias_call_resolves_to_symbol_in_imported_file(
     refs = db.get_refs(symbol_id=caller["id"])
     execute_ref = next(ref for ref in refs if ref["to_symbol_name"] == "execute")
     assert execute_ref["to_symbol_id"] == service_run[0]
+
+
+def test_python_module_import_call_resolves_to_symbol_in_imported_file(
+    tmp_path: Path,
+) -> None:
+    """A module-qualified call must not resolve to an unrelated global symbol."""
+    (tmp_path / "service.py").write_text("def run() -> str:\n    return 'service'\n")
+    (tmp_path / "caller.py").write_text(
+        "import service\n\ndef caller() -> str:\n    return service.run()\n"
+    )
+    (tmp_path / "unrelated.py").write_text("def run() -> str:\n    return 'unrelated'\n")
+
+    pipeline = IndexerPipeline(str(tmp_path), languages=["python"])
+    pipeline.index_project_sync()
+
+    db = pipeline.project_db
+    caller = db.lookup_symbols("caller", kind="function")[0]
+    service_file = db.get_file(path="service.py")
+    assert service_file is not None
+    service_run = db.conn.execute(
+        "SELECT id FROM symbols WHERE file_id = ? AND name = 'run'",
+        (service_file["id"],),
+    ).fetchone()
+    assert service_run is not None
+
+    run_ref = next(ref for ref in db.get_refs(symbol_id=caller["id"]) if ref["to_symbol_name"] == "run")
+    assert run_ref["to_symbol_id"] == service_run[0]
+
+
+def test_python_one_hop_reexport_resolves_to_original_symbol(tmp_path: Path) -> None:
+    """A named import forwarded once through an in-project facade stays precise."""
+    (tmp_path / "service.py").write_text("def run() -> str:\n    return 'service'\n")
+    (tmp_path / "facade.py").write_text("from service import run\n")
+    (tmp_path / "caller.py").write_text(
+        "from facade import run\n\ndef caller() -> str:\n    return run()\n"
+    )
+    (tmp_path / "unrelated.py").write_text("def run() -> str:\n    return 'unrelated'\n")
+
+    pipeline = IndexerPipeline(str(tmp_path), languages=["python"])
+    pipeline.index_project_sync()
+
+    db = pipeline.project_db
+    caller = db.lookup_symbols("caller", kind="function")[0]
+    service_file = db.get_file(path="service.py")
+    assert service_file is not None
+    service_run = db.conn.execute(
+        "SELECT id FROM symbols WHERE file_id = ? AND name = 'run'",
+        (service_file["id"],),
+    ).fetchone()
+    assert service_run is not None
+
+    run_ref = next(ref for ref in db.get_refs(symbol_id=caller["id"]) if ref["to_symbol_name"] == "run")
+    assert run_ref["to_symbol_id"] == service_run[0]

--- a/tests/integration/test_import_alias_resolution.py
+++ b/tests/integration/test_import_alias_resolution.py
@@ -1,0 +1,61 @@
+"""End-to-end coverage for import-aware cross-file call resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tessera.indexer import IndexerPipeline
+
+
+@pytest.mark.parametrize(
+    ("language", "service_name", "caller_name", "service_source", "caller_source"),
+    [
+        (
+            "python",
+            "service.py",
+            "caller.py",
+            "def run() -> str:\n    return 'service'\n",
+            "from service import run as execute\n\ndef caller() -> str:\n    return execute()\n",
+        ),
+        (
+            "typescript",
+            "service.ts",
+            "caller.ts",
+            "export function run(): string { return 'service'; }\n",
+            "import { run as execute } from './service';\n\nexport function caller(): string { return execute(); }\n",
+        ),
+    ],
+)
+def test_import_alias_call_resolves_to_symbol_in_imported_file(
+    tmp_path: Path,
+    language: str,
+    service_name: str,
+    caller_name: str,
+    service_source: str,
+    caller_source: str,
+) -> None:
+    """An import alias must beat an unrelated same-named local candidate."""
+    (tmp_path / service_name).write_text(service_source)
+    (tmp_path / caller_name).write_text(caller_source)
+    (tmp_path / f"unrelated.{service_name.rsplit('.', 1)[1]}").write_text(
+        service_source.replace("run", "execute")
+    )
+
+    pipeline = IndexerPipeline(str(tmp_path), languages=[language])
+    pipeline.index_project_sync()
+
+    db = pipeline.project_db
+    caller = db.lookup_symbols("caller", kind="function")[0]
+    service_file = db.get_file(path=service_name)
+    assert service_file is not None
+    service_run = db.conn.execute(
+        "SELECT id FROM symbols WHERE file_id = ? AND name = 'run'",
+        (service_file["id"],),
+    ).fetchone()
+    assert service_run is not None
+
+    refs = db.get_refs(symbol_id=caller["id"])
+    execute_ref = next(ref for ref in refs if ref["to_symbol_name"] == "execute")
+    assert execute_ref["to_symbol_id"] == service_run[0]

--- a/tests/integration/test_indexer.py
+++ b/tests/integration/test_indexer.py
@@ -102,9 +102,13 @@ class MockProjectDB:
         """Get the old hash from the last upsert_file call."""
         return self._old_hash
 
-    def get_file(self, file_id):
-        """Get file record by ID."""
-        return self.files.get(file_id)
+    def get_file(self, file_id=None, path=None):
+        """Get file record by ID or path."""
+        if file_id is not None:
+            return self.files.get(file_id)
+        if path is not None:
+            return next((file for file in self.files.values() if file['path'] == path), None)
+        raise ValueError("Must provide file_id or path")
 
     def insert_symbols(self, symbol_dicts):
         """Insert symbols, return list of symbol IDs."""
@@ -552,8 +556,6 @@ class TestIndexProject:
 
     def test_index_stats_accumulation(self, temp_project_dir, mock_project_db):
         """Test that IndexStats accumulates correctly."""
-        pipeline = IndexerPipeline(str(temp_project_dir), project_db=mock_project_db)
-
         stats = IndexStats()
         stats.files_processed = 3
         stats.symbols_extracted = 10
@@ -608,6 +610,9 @@ class TestSearch:
 
         assert len(results) == 1
         assert results[0]['id'] == 1
+        mock_hybrid.assert_called_once_with(
+            'test query', None, mock_project_db, graph=None, limit=10
+        )
 
     @patch('tessera.indexer._pipeline.hybrid_search')
     def test_search_with_embeddings(self, mock_hybrid, temp_project_dir, mock_project_db):
@@ -626,6 +631,7 @@ class TestSearch:
 
         results = pipeline.search('query', limit=10)
 
+        assert results == []
         assert mock_embedding_client.embed_single.called
 
 

--- a/tests/integration/test_indexer_assets.py
+++ b/tests/integration/test_indexer_assets.py
@@ -175,17 +175,15 @@ class TestIgnorePatterns:
 class TestChangeDetection:
     """Test that unchanged assets are skipped on re-index."""
 
-    def test_reindex_same_asset_succeeds(self, pipeline, project_dir):
-        """Re-indexing the same asset succeeds (change detection is hash-based in production)."""
+    def test_reindex_same_asset_is_skipped(self, pipeline, project_dir):
+        """An unchanged asset is not parsed and stored again."""
         png_path = str(project_dir / "assets" / "images" / "logo.png")
 
         result1 = pipeline.index_file_sync(png_path)
         assert result1['status'] == 'indexed'
 
-        # Second index still succeeds — ProjectDB.get_old_hash() would enable
-        # skip-unchanged in production, but it's not implemented in all DB layers.
         result2 = pipeline.index_file_sync(png_path)
-        assert result2['status'] in ('indexed', 'skipped')
+        assert result2 == {'status': 'skipped', 'reason': 'unchanged'}
 
     def test_reindex_changed_asset(self, pipeline, project_dir):
         """Modified assets are re-indexed."""

--- a/tests/integration/test_phase2_integration.py
+++ b/tests/integration/test_phase2_integration.py
@@ -57,10 +57,11 @@ class TestServerWiring:
         assert isinstance(server_mod._db_cache[server_mod._locked_project], ProjectDB)
         assert isinstance(server_mod._global_db, GlobalDB)
 
-    async def test_server_lists_18_tools(self, wired_server):
+    async def test_server_lists_advanced_tools(self, wired_server):
         tools = await wired_server.list_tools()
         tool_names = [t.name for t in tools]
-        assert len(tool_names) == 19  # Phase 5 added the events tool.
+        assert len(tool_names) == 20
+        assert "explore" in tool_names
         assert "register_project" in tool_names
         assert "status" in tool_names
         assert "cross_refs" in tool_names

--- a/tests/integration/test_phase2_integration.py
+++ b/tests/integration/test_phase2_integration.py
@@ -60,7 +60,7 @@ class TestServerWiring:
     async def test_server_lists_18_tools(self, wired_server):
         tools = await wired_server.list_tools()
         tool_names = [t.name for t in tools]
-        assert len(tool_names) == 18  # Updated for Phase 4 (doc_search, drift_train)
+        assert len(tool_names) == 19  # Phase 5 added the events tool.
         assert "register_project" in tool_names
         assert "status" in tool_names
         assert "cross_refs" in tool_names

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
 from tessera.db import GlobalDB, ProjectDB
 from tessera.indexer import IndexStats
@@ -47,7 +48,8 @@ class TestServerCreation:
         assert "delete_collection_tool" in tool_names
         assert "doc_search_tool" in tool_names
         assert "drift_train" in tool_names
-        assert len(tool_names) == 18
+        assert "events" in tool_names
+        assert len(tool_names) == 19
 
 
 class TestSearchTool:
@@ -95,7 +97,7 @@ class TestReferencesTool:
 
     async def test_references_tool_missing_symbol(self, server):
         """FastMCP validates required params — should error."""
-        with pytest.raises(Exception):
+        with pytest.raises(ToolError):
             await server.call_tool("references", {"kind": "all"})
 
 
@@ -107,7 +109,7 @@ class TestFileContextTool:
         assert len(result.content) > 0
 
     async def test_file_context_tool_missing_path(self, server):
-        with pytest.raises(Exception):
+        with pytest.raises(ToolError):
             await server.call_tool("file_context", {})
 
 
@@ -318,7 +320,7 @@ class TestMultiProjectServerCreation:
             srv = create_server(project_path=None, global_db_path=global_db_path)
             async with Client(srv) as client:
                 tools = await client.list_tools()
-                assert len([t.name for t in tools]) == 18
+                assert len([t.name for t in tools]) == 19
 
     async def test_no_projects_returns_error(self):
         """Multi-project mode with no registered projects returns error."""

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -28,6 +28,19 @@ async def server():
 class TestServerCreation:
     """Test server initialization and tool registration."""
 
+    async def test_compact_profile_exposes_only_explore(self):
+        """Coding-agent defaults must present one task-oriented entry point."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            srv = create_server(
+                tmpdir,
+                os.path.join(tmpdir, "global.db"),
+                tool_profile="compact",
+            )
+            async with Client(srv) as client:
+                tools = await client.list_tools()
+
+        assert [tool.name for tool in tools] == ["explore"]
+
     async def test_server_creates_tools(self, server):
         """Verify the server registers all tools."""
         tools = await server.list_tools()
@@ -49,7 +62,8 @@ class TestServerCreation:
         assert "doc_search_tool" in tool_names
         assert "drift_train" in tool_names
         assert "events" in tool_names
-        assert len(tool_names) == 19
+        assert "explore" in tool_names
+        assert len(tool_names) == 20
 
 
 class TestSearchTool:
@@ -320,7 +334,7 @@ class TestMultiProjectServerCreation:
             srv = create_server(project_path=None, global_db_path=global_db_path)
             async with Client(srv) as client:
                 tools = await client.list_tools()
-                assert len([t.name for t in tools]) == 19
+                assert len([t.name for t in tools]) == 20
 
     async def test_no_projects_returns_error(self):
         """Multi-project mode with no registered projects returns error."""

--- a/tests/unit/test_benchmark_competitive.py
+++ b/tests/unit/test_benchmark_competitive.py
@@ -6,6 +6,7 @@ import pytest
 from scripts.benchmark_competitive import (
     parse_codegraph_files,
     rank_expected,
+    ranker_routing_analysis,
     summarize,
     validate_ground_truth,
 )
@@ -62,3 +63,30 @@ def test_ground_truth_accepts_markdown_document(tmp_path: Path) -> None:
         "expected_files": ["README.md"],
     }
     validate_ground_truth([case], {"fixture": tmp_path})
+
+
+def test_ranker_routing_uses_jina_only_for_code() -> None:
+    rows = [
+        {
+            "engine": engine,
+            "category": category,
+            "supported": True,
+            "rank": rank,
+            "latency_ms": 1.0,
+        }
+        for category, base_rank, reranked_rank in (
+            ("code", 4, 1),
+            ("document", 1, 4),
+            ("cross", 2, 5),
+        )
+        for engine, rank in (
+            ("tessera_bge_small", base_rank),
+            ("tessera_bge_small_jina_tiny", reranked_rank),
+        )
+    ]
+    result = ranker_routing_analysis(rows)
+    assert result["post_hoc"] is True
+    assert result["overall"]["queries_supported"] == 3
+    assert result["categories"]["code"]["mrr_at_10"] == 1.0
+    assert result["categories"]["document"]["mrr_at_10"] == 1.0
+    assert result["categories"]["cross"]["mrr_at_10"] == 0.5

--- a/tests/unit/test_benchmark_competitive.py
+++ b/tests/unit/test_benchmark_competitive.py
@@ -1,0 +1,64 @@
+"""Tests for competitive benchmark scoring and output adapters."""
+
+from pathlib import Path
+
+import pytest
+from scripts.benchmark_competitive import (
+    parse_codegraph_files,
+    rank_expected,
+    summarize,
+    validate_ground_truth,
+)
+
+
+def test_parse_codegraph_files_preserves_unique_source_order() -> None:
+    output = """
+**Source Code**
+**`src/first.py`** — symbols
+**`src/second.ts`** — symbols
+**`src/first.py`** — duplicate
+"""
+    assert parse_codegraph_files(output) == ["src/first.py", "src/second.ts"]
+
+
+def test_rank_expected_accepts_full_or_partial_expected_paths() -> None:
+    paths = ["src/noise.py", "packages/core/target.ts"]
+    assert rank_expected(paths, ["core/target.ts"]) == 2
+    assert rank_expected(paths, ["missing.ts"]) is None
+
+
+def test_summary_excludes_unsupported_rows_from_denominator() -> None:
+    rows = [
+        {"supported": True, "rank": 1, "latency_ms": 10.0},
+        {"supported": True, "rank": None, "latency_ms": 20.0},
+        {"supported": False, "rank": None, "latency_ms": None},
+    ]
+    result = summarize(rows)
+    assert result["queries_total"] == 3
+    assert result["queries_supported"] == 2
+    assert result["queries_unsupported"] == 1
+    assert result["mrr_at_10"] == 0.5
+    assert result["top_10"] == 0.5
+
+
+def test_ground_truth_requires_category_compatible_file(tmp_path: Path) -> None:
+    (tmp_path / "guide.md").write_text("guide", encoding="utf-8")
+    case = {
+        "repository": "fixture",
+        "category": "code",
+        "description": "Mislabeled code query",
+        "expected_files": ["guide.md"],
+    }
+    with pytest.raises(ValueError, match="Mislabeled code query"):
+        validate_ground_truth([case], {"fixture": tmp_path})
+
+
+def test_ground_truth_accepts_markdown_document(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("guide", encoding="utf-8")
+    case = {
+        "repository": "fixture",
+        "category": "document",
+        "description": "Markdown query",
+        "expected_files": ["README.md"],
+    }
+    validate_ground_truth([case], {"fixture": tmp_path})

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -2,7 +2,79 @@
 
 import numpy as np
 
-from tessera.search import cosine_search, rrf_merge
+from tessera.search import SearchType, cosine_search, hybrid_search, rrf_merge
+
+
+def test_bm25_short_circuit_honors_file_dedup() -> None:
+    """High-confidence keyword search must still return unique files when requested."""
+
+    class FakeDB:
+        chunks = {
+            1: {"file_id": 1, "file_path": "docs/first.rst", "content": "first a"},
+            2: {"file_id": 1, "file_path": "docs/first.rst", "content": "first b"},
+            3: {"file_id": 1, "file_path": "docs/first.rst", "content": "first c"},
+            4: {"file_id": 1, "file_path": "docs/first.rst", "content": "first d"},
+            5: {"file_id": 2, "file_path": "docs/second.rst", "content": "second"},
+        }
+
+        def keyword_search(self, *_args, limit, **_kwargs):
+            results = [
+                {"id": 1, "score": -10.0},
+                {"id": 2, "score": -1.0},
+                {"id": 3, "score": -0.9},
+                {"id": 4, "score": -0.8},
+                {"id": 5, "score": -0.7},
+            ]
+            return results[:limit]
+
+        def get_chunk(self, chunk_id):
+            return self.chunks[chunk_id]
+
+    results = hybrid_search(
+        "first",
+        query_embedding=None,
+        db=FakeDB(),
+        limit=2,
+        search_types=[SearchType.LEX],
+        file_dedup=True,
+    )
+
+    assert [result["file_path"] for result in results] == [
+        "docs/first.rst",
+        "docs/second.rst",
+    ]
+
+
+def test_bm25_short_circuit_fills_unique_file_limit_semantically() -> None:
+    """A single keyword hit must not suppress enough semantic file results."""
+
+    class FakeDB:
+        chunks = {
+            1: {"file_id": 1, "file_path": "docs/first.rst", "content": "first"},
+            2: {"file_id": 2, "file_path": "docs/second.rst", "content": "second"},
+        }
+
+        def keyword_search(self, *_args, **_kwargs):
+            return [{"id": 1, "score": -10.0}]
+
+        def get_all_embeddings(self):
+            return [1, 2], np.array([[1.0, 0.0], [0.9, 0.1]], dtype=np.float32)
+
+        def get_chunk(self, chunk_id):
+            return self.chunks[chunk_id]
+
+    results = hybrid_search(
+        "first",
+        query_embedding=np.array([1.0, 0.0], dtype=np.float32),
+        db=FakeDB(),
+        limit=2,
+        file_dedup=True,
+    )
+
+    assert [result["file_path"] for result in results] == [
+        "docs/first.rst",
+        "docs/second.rst",
+    ]
 
 
 class TestRRFMerge:
@@ -332,6 +404,7 @@ class TestExtractSnippet:
     def test_semantic_scoring_finds_try_except(self):
         """Semantic scoring picks try/except over a comment containing query words."""
         import numpy as np
+
         from tessera.search import extract_snippet
 
         # Lines 0-4 are filler, lines 5-7 are the error handling block.
@@ -382,6 +455,7 @@ class TestExtractSnippet:
     def test_semantic_scoring_fallback_on_error(self):
         """Falls back to keyword scoring when embed_fn raises."""
         import numpy as np
+
         from tessera.search import extract_snippet
 
         content = "alpha\nbeta\nerror_handler\ndelta"

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ wheels = [
 
 [[package]]
 name = "async-hooks"
-version = "0.1.0"
+version = "0.3.0"
 source = { directory = "../lib/async-hooks" }
 
 [package.metadata]
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "tessera-idx"
-version = "0.10.1"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "async-hooks" },


### PR DESCRIPTION
## Summary

Improve graph precision for import-aware cross-file calls, make Tessera easier for coding agents to adopt through a compact default MCP surface, and add a reproducible Tessera-vs-CodeGraph benchmark across Python, TypeScript, and documentation.

## Changes

### Cross-file graph resolution

- Resolve top-level named Python and TypeScript/JavaScript import aliases against their relative source modules.
- Resolve Python `import module; module.member()` calls when the receiver is a simple module binding.
- Follow exact named import re-exports through in-project facade modules, with cycle protection.
- Preserve precision: dynamic dispatch, wildcards, chained receivers, and ambiguous or dotted unaliased package imports remain unresolved.
- Add `scripts/benchmark_cross_file_resolution.py`, an exact-target collision fixture for Tessera versus CodeGraph.

### MCP tool adoption

- Add a bounded, read-only `explore` context pack that combines hybrid code search, file symbol outlines, and exact reference/caller slices.
- Default CLI and HMR MCP launches to a one-tool compact profile; `--tool-profile advanced` retains `explore` plus the existing 19 specialized tools.
- Keep programmatic `create_server()` advanced by default for compatibility.
- Document both profiles in the getting-started guide.

### Competitive benchmark and retrieval fix

- Add a pinned, machine-readable 58-case benchmark over Next.js v16.1.6 and Flask 3.1.2: 23 normalized code queries, 19 document queries (Markdown/MDX/RST), and 16 mixed queries.
- Compare BGE-small hybrid retrieval, BGE-small + Jina-tiny, CodeGraph 1.4.1 on its supported source-code subset, and a post-hoc code-only reranker policy.
- Validate all expected labels against category-compatible files and exclude unsupported CodeGraph document/mixed rows from scoring.
- Fix BM25 short-circuit/file-dedup candidate collapse found by the smoke benchmark; add red/green duplicate-pool and semantic-fallback tests.
- Record the full report in `docs/benchmark-competitive-2026-07-14.md` and raw per-query data in `benchmarks/competitive-2026-07-14.json`.

### Adjacent correctness

- Correct `IndexerPipeline.search()` argument forwarding and unchanged-file detection.
- Register standalone projects on demand during direct file indexing.
- Align MCP inventory docs/tests.

## Results

- Normalized code MRR@10: Tessera + Jina-tiny **0.577**, Tessera base **0.506**, CodeGraph **0.413** (23 identical source-code queries).
- Code Top-10: Tessera + Jina-tiny **74%**, Tessera base **61%**, CodeGraph **48%**.
- All-content MRR@10: base **0.610**, global rerank **0.588**, post-hoc code-only rerank **0.638**.
- Exact cross-file targets: Tessera **4/4**, CodeGraph **3/4**.
- Smoke before/after retrieval fix: base MRR **0.536 → 0.604**, reranked **0.554 → 0.648**; Flask document Top-10 **0/2 → 2/2**.

## Validation

- Independent JSON audit: 174 rows, 139 supported executions, 35 explicitly unsupported CodeGraph rows; every rank, reciprocal rank, denominator, and derived routing metric recomputed successfully.
- Final branch gate: **474 unit tests** and **8 search/PPR integration tests** passed.
- Ruff, targeted Pyright (0 errors), `git diff --check`, exact graph fixture, and two complete 139-run benchmark passes passed.
- Compact live agent probe: the prior configuration made zero Tessera calls; with compact `explore`, the agent invoked it and produced the correct Next.js App Route dispatch explanation. This is directional N=1 evidence only.
- The benchmark is curated/file-level rather than independently blinded, and latency is directional because Tessera runs in-process while CodeGraph starts a fresh CLI process per query.

## 2026-07-14 merge-gate refresh

- Retargeted to the newly created `develop` branch at the exact current `origin/main` tip.
- Reworded the post-hoc code-only result as a diagnostic oracle, removed language/content routing guidance, and removed the benchmark-derived filename coefficient recommendation. No product defaults were changed by this cleanup.
- Updated issue #12 to require repository-level splits and separate experiment/integration PRs.
- Unit suite: **474 passed**.
- Changed integration/unit files: **142 passed**.
- Strict MkDocs build, changed-file Ruff (excluding one pre-existing lint-debt fixture), targeted Pyright, and `git diff --check`: passed.
- A full-suite run reached **175 passed, 1 skipped** before the real-federation latency test failed at 2.2s p95. The same test fails on untouched `origin/develop` at 6.2s p95, so this is a pre-existing/environment-sensitive performance gate rather than a PR regression. It remains visible for PR-01/PR-02 instead of being weakened here.
- GitHub has no review threads, review blockers, or required checks on this PR.