### PR TITLE
Experiment: real two-stage retrieval and rerank pools

### DIFF
--- a/benchmarks/development-two-stage-2026-07-14.json
+++ b/benchmarks/development-two-stage-2026-07-14.json
@@ -1,0 +1,6375 @@
+{
+  "limitations": [
+    "This is a public development treatment, not a sealed holdout result.",
+    "File-level labels do not score snippet usefulness, answer synthesis, or agent task completion.",
+    "The four stages diagnose one predeclared mechanism; they are not a model or pool-size sweep.",
+    "Segment samples are small and are reported as guardrails rather than tuning targets."
+  ],
+  "metadata": {
+    "command": [
+      "scripts/benchmark_two_stage.py",
+      "--tier",
+      "quick",
+      "--output",
+      "benchmarks/development-two-stage-2026-07-14.json"
+    ],
+    "document_budget_policy": "visible_limit_context_conserving",
+    "embedding_model": "BAAI/bge-small-en-v1.5",
+    "engine_order_rotated": true,
+    "evaluation_split": "development",
+    "generated_at": "2026-07-14T10:16:01.219655+00:00",
+    "manifest_path": "benchmarks/corpora/v1/manifest.yaml",
+    "manifest_schema_version": 1,
+    "manifest_sha256": "0e84423ee5f116554af104908b0ba845cee25bc69bfecc38cb813e3deab1c701",
+    "max_document_chars": 2048,
+    "max_pool_size": 50,
+    "max_raw_fetch_size": 250,
+    "platform": "macOS-15.5-arm64-arm-64bit-Mach-O",
+    "pool_multiplier": 3,
+    "python": "3.14.3",
+    "query_cases": 30,
+    "random_seed": 1729,
+    "raw_fetch_multiplier": 5,
+    "repository_revisions": {
+      "attrs": "d544dd2dacb4cbd660891e323ad92751ba65b4e0",
+      "dry-configurable": "e5e025dfddb481485affe6bb7363d3cf37f153b5",
+      "fastroute": "1c961398bef1ff6ecd8b273bef651d7afe90312b",
+      "hono": "b2ae3a2204a48ce15a26448fd746d39745eb1837",
+      "pflag": "5fdac2d16c16d60605cb8baa887e8c5c38ef623f",
+      "swift-argument-parser": "e579882f95579e7d7eb8c8068a5925c65d361e91"
+    },
+    "reranking_model": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "selection_allowed": true,
+    "tessera_revision": "e8dbc0a414da6dd9857a693a746b644871a08818",
+    "tier": "quick",
+    "top_k": 10
+  },
+  "queries": [
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 2505.97,
+      "max_document_chars": 4343,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_make.py",
+        "src/attr/validators.py",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 20463.62,
+      "max_document_chars": 9396,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.733333,
+        "known_files": 30,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_funcs.py",
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 11961.31,
+      "max_document_chars": 7801,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "src/attr/validators.py",
+        "src/attrs/__init__.py",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 3483.85,
+      "max_document_chars": 682,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_make.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py",
+        "src/attrs/__init__.py",
+        "src/attr/__init__.py",
+        "src/attr/validators.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 1861.94,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py",
+        "src/attr/__init__.py",
+        "src/attr/_make.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 7551.8,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.766667,
+        "known_files": 30,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 16365.25,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/converters.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 7025.79,
+      "max_document_chars": 682,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/setters.py",
+        "src/attr/converters.py",
+        "src/attr/filters.py",
+        "src/attrs/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 2253.05,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_make.py",
+        "src/attr/_compat.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 7562.16,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.766667,
+        "known_files": 30,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_cmp.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 6257.85,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_cmp.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 3734.79,
+      "max_document_chars": 682,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_funcs.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_compat.py",
+        "src/attr/_cmp.py",
+        "src/attrs/__init__.py",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 1985.66,
+      "max_document_chars": 3507,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/index.md",
+        "docs/api.rst",
+        "docs/api-attr.rst"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 8188.59,
+      "max_document_chars": 3533,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.5,
+        "known_files": 30,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/types.md",
+        "docs/how-does-it-work.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/extending.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 8260.81,
+      "max_document_chars": 3533,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.433333,
+        "known_files": 30,
+        "unique_files": 17
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/types.md",
+        "docs/how-does-it-work.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/extending.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 4233.84,
+      "max_document_chars": 682,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.433333,
+        "known_files": 30,
+        "unique_files": 17
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/overview.md",
+        "docs/types.md",
+        "README.md",
+        "docs/how-does-it-work.md",
+        "docs/glossary.md",
+        "docs/index.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 2753.75,
+      "max_document_chars": 9764,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.4,
+        "known_files": 10,
+        "unique_files": 6
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.4,
+        "known_files": 10,
+        "unique_files": 6
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_make.py",
+        "docs/api.rst",
+        "docs/index.md",
+        "src/attr/validators.py",
+        "src/attr/setters.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 6322.05,
+      "max_document_chars": 16826,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.6,
+        "known_files": 30,
+        "unique_files": 12
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "docs/examples.md",
+        "README.md",
+        "docs/api.rst"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 8253.03,
+      "max_document_chars": 7076,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_next_gen.py",
+        "README.md",
+        "docs/api.rst",
+        "src/attr/_make.py",
+        "docs/how-does-it-work.md",
+        "docs/api-attr.rst",
+        "docs/extending.md",
+        "docs/index.md",
+        "docs/examples.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 2336.58,
+      "max_document_chars": 682,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "README.md",
+        "docs/api.rst",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "src/attrs/__init__.py",
+        "docs/api-attr.rst",
+        "src/attr/__init__.py",
+        "docs/examples.md",
+        "docs/extending.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 1278.33,
+      "max_document_chars": 20131,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/serve-static/index.ts",
+        "src/request.test.ts",
+        "src/client/client.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 6438.95,
+      "max_document_chars": 62576,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.133333,
+        "known_files": 30,
+        "unique_files": 26
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/trailing-slash/index.test.ts",
+        "src/middleware/context-storage/index.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 5801.98,
+      "max_document_chars": 62576,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/trailing-slash/index.test.ts",
+        "src/middleware/context-storage/index.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 1941.7,
+      "max_document_chars": 682,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/request-id/index.test.ts",
+        "src/middleware/powered-by/index.ts",
+        "src/middleware/pretty-json/index.test.ts",
+        "src/middleware/compress/index.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 1283.42,
+      "max_document_chars": 18499,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/client/client.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/middleware/language/language.ts",
+        "src/middleware/jwk/jwk.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 6177.03,
+      "max_document_chars": 57250,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/client/client.ts",
+        "src/adapter/aws-lambda/handler.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 10262.92,
+      "max_document_chars": 57250,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/client/client.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/middleware/language/language.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 4486.42,
+      "max_document_chars": 682,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/utils/jwt/jws.ts",
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/client/client.ts",
+        "src/validator/validator.ts",
+        "src/helper/cookie/index.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/middleware/language/language.ts",
+        "src/adapter/lambda-edge/handler.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 1429.55,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/index.test.ts",
+        "src/client/client.test.ts",
+        "src/utils/basic-auth.ts",
+        "src/utils/headers.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 4872.52,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/csrf/index.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/adapter/aws-lambda/conninfo.test.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 6098.27,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/csrf/index.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/adapter/aws-lambda/conninfo.test.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 1970.56,
+      "max_document_chars": 682,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.test.ts",
+        "src/validator/validator.ts",
+        "src/middleware/jwt/index.test.ts",
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/bearer-auth/index.test.ts",
+        "src/utils/basic-auth.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 166.84,
+      "max_document_chars": 3330,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 1181.67,
+      "max_document_chars": 3530,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 2055.89,
+      "max_document_chars": 3530,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "document_char_budget": 2048,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 1228.4,
+      "max_document_chars": 2048,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 1394.35,
+      "max_document_chars": 30906,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/helper/streaming/stream.test.ts",
+        "src/jsx/streaming.test.tsx",
+        "src/helper/streaming/stream.ts",
+        "src/utils/stream.test.ts",
+        "src/utils/stream.ts",
+        "src/adapter/service-worker/types.ts",
+        "src/helper/streaming/text.test.ts",
+        "src/client/utils.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 5158.13,
+      "max_document_chars": 46036,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/adapter/bun/websocket.test.ts",
+        "src/helper/websocket/index.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/hono-base.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/websocket/index.test.ts",
+        "src/helper/streaming/stream.test.ts",
+        "src/jsx/streaming.test.tsx"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 4205.05,
+      "max_document_chars": 46036,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/adapter/bun/websocket.test.ts",
+        "src/helper/websocket/index.ts",
+        "src/adapter/deno/websocket.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/hono-base.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/websocket/index.test.ts",
+        "src/helper/streaming/stream.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 3066.0,
+      "max_document_chars": 682,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 7,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 0.142857,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/hono-base.ts",
+        "src/adapter/deno/websocket.ts",
+        "src/helper/streaming/stream.test.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/helper/streaming/text.test.ts",
+        "src/adapter/service-worker/types.ts",
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/jsx/streaming.ts",
+        "src/helper/streaming/stream.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 1915.47,
+      "max_document_chars": 3724,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/Route.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/DataGenerator/GroupPosBased.php",
+        "src/DataGenerator/CharCountBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/DataGenerator/MarkBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 4361.87,
+      "max_document_chars": 3819,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/ConfigureRoutes.php",
+        "src/GenerateUri.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 4713.64,
+      "max_document_chars": 3819,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/ConfigureRoutes.php",
+        "src/BadRouteException.php",
+        "src/GenerateUri.php",
+        "src/Route.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/functions.php",
+        "src/DataGenerator.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 2217.57,
+      "max_document_chars": 682,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/Route.php",
+        "src/DataGenerator.php",
+        "src/ConfigureRoutes.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/functions.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 1940.54,
+      "max_document_chars": 3401,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": null,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 0.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Dispatcher/Result/Matched.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 4939.34,
+      "max_document_chars": 3819,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": null,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.3,
+        "known_files": 30,
+        "unique_files": 21
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/RouteParser/Std.php",
+        "src/Dispatcher/CharCountBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 5448.0,
+      "max_document_chars": 5337,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": 8,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.125,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/RouteParser/Std.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/Result/MethodNotAllowed.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Dispatcher/Result/Matched.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 1197.24,
+      "max_document_chars": 682,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/Result/Matched.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/Result/MethodNotAllowed.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 1394.44,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteCollector.php",
+        "src/Cache/Psr16Cache.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Cache.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 5559.12,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.233333,
+        "known_files": 30,
+        "unique_files": 23
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/RouteParser.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 8736.01,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteParser/Std.php",
+        "src/GenerateUri.php",
+        "src/RouteCollector.php",
+        "src/RouteParser.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 5020.21,
+      "max_document_chars": 682,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Cache/FileCache.php",
+        "src/GenerateUri.php",
+        "src/functions.php",
+        "src/Cache.php",
+        "src/ConfigureRoutes.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/DataGenerator.php",
+        "src/Cache/Psr16Cache.php",
+        "src/RouteParser.php",
+        "src/FastRoute.php"
+      ]
+    },
+    {
+      "candidate_budget": 3,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 1186.43,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 3,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 3,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 3,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 3,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 1589.11,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 593.9,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "document_char_budget": 2048,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 758.87,
+      "max_document_chars": 2048,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 1761.74,
+      "max_document_chars": 3553,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Route.php",
+        "src/DataGenerator/MarkBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 5056.21,
+      "max_document_chars": 3819,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.3,
+        "known_files": 30,
+        "unique_files": 21
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/RouteParser.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/RouteCollector.php",
+        "src/ConfigureRoutes.php",
+        "src/RouteParser/Std.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 14610.37,
+      "max_document_chars": 3819,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/RouteParser.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/RouteCollector.php",
+        "src/BadRouteException.php",
+        "src/ConfigureRoutes.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/CharCountBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 1255.97,
+      "max_document_chars": 682,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/RouteParser.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/GeneratedUri.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/RouteCollector.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 1377.38,
+      "max_document_chars": 1376,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "flag.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 6452.39,
+      "max_document_chars": 4013,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.7,
+        "known_files": 30,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 4602.25,
+      "max_document_chars": 4444,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "string_slice.go",
+        "flag_test.go",
+        "flag.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "errors.go",
+        "golangflag.go",
+        "bool_test.go",
+        "bytes.go",
+        "string.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 2993.0,
+      "max_document_chars": 682,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "flag_test.go",
+        "example_test.go",
+        "bytes.go",
+        "errors.go",
+        "golangflag.go",
+        "string.go",
+        "bool.go",
+        "bool_slice_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 3757.72,
+      "max_document_chars": 7053,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "flag.go",
+        "bool.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 5242.78,
+      "max_document_chars": 7053,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.633333,
+        "known_files": 30,
+        "unique_files": 11
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 6307.37,
+      "max_document_chars": 4444,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 7,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.142857,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "bool_func_go1.21_test.go",
+        "string_to_string.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "string_to_string_test.go",
+        "flag.go",
+        "errors.go",
+        "bytes.go",
+        "bool_func.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 3052.21,
+      "max_document_chars": 682,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 6,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.166667,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "example_test.go",
+        "bool_func_go1.21_test.go",
+        "string_to_string.go",
+        "bool_slice_test.go",
+        "flag.go",
+        "bool_test.go",
+        "bytes.go",
+        "bool_slice.go",
+        "errors.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 824.14,
+      "max_document_chars": 1039,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "bytes.go",
+        "flag_test.go",
+        "ipnet_slice_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 7264.89,
+      "max_document_chars": 4444,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "bytes.go",
+        "golangflag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 3847.9,
+      "max_document_chars": 4444,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "uint_slice_test.go",
+        "bytes.go",
+        "duration_slice_test.go",
+        "golangflag.go",
+        "string_slice_test.go",
+        "string_array_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 3305.99,
+      "max_document_chars": 682,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "string_slice.go",
+        "flag.go",
+        "string_to_string.go",
+        "string_slice_test.go",
+        "uint_slice_test.go",
+        "uint_slice.go",
+        "int32_slice.go",
+        "int64_slice.go",
+        "duration_slice_test.go",
+        "float32_slice.go"
+      ]
+    },
+    {
+      "candidate_budget": 2,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 1258.13,
+      "max_document_chars": 3464,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 2,
+        "duplicate_file_rate": 0.5,
+        "known_files": 2,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 2,
+        "duplicate_file_rate": 0.5,
+        "known_files": 2,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 2469.17,
+      "max_document_chars": 3476,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 4037.59,
+      "max_document_chars": 3476,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "document_char_budget": 1462,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 3059.07,
+      "max_document_chars": 1462,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".editorconfig",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 2693.89,
+      "max_document_chars": 3476,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "errors.go",
+        "flag_test.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 12055.11,
+      "max_document_chars": 4013,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 30,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 6651.11,
+      "max_document_chars": 3476,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "example_test.go",
+        "errors.go",
+        "flag_test.go",
+        "bool_func_test.go",
+        "func_test.go",
+        "golangflag.go",
+        "bool.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 1392.83,
+      "max_document_chars": 682,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "example_test.go",
+        "README.md",
+        "errors.go",
+        "flag_test.go",
+        "bool_func_test.go",
+        "bool.go",
+        "func_test.go",
+        "ipnet.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 1928.6,
+      "max_document_chars": 11728,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/ParentCommand.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 6305.25,
+      "max_document_chars": 18364,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 4452.99,
+      "max_document_chars": 18364,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandGroup.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/Errors.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 4218.46,
+      "max_document_chars": 682,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandGroup.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift",
+        "Sources/ArgumentParser/Parsable Properties/ParentCommand.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 2373.65,
+      "max_document_chars": 13431,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 8323.96,
+      "max_document_chars": 13431,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 6,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.166667,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.5,
+        "known_files": 30,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 5005.97,
+      "max_document_chars": 8947,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 8,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.125,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 2464.27,
+      "max_document_chars": 682,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsing/ParserError.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 1258.4,
+      "max_document_chars": 6714,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsable Properties/OptionGroup.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDecoder.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 7633.13,
+      "max_document_chars": 6714,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.533333,
+        "known_files": 30,
+        "unique_files": 14
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDecoder.swift",
+        "Sources/ArgumentParser/Parsing/Parsed.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 5469.44,
+      "max_document_chars": 8088,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Validators/PositionalArgumentsValidator.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift",
+        "Sources/ArgumentParser/Validators/UniqueNamesValidator.swift",
+        "Sources/ArgumentParser/Utilities/SequenceExtensions.swift",
+        "Sources/ArgumentParser/Parsable Properties/OptionGroup.swift",
+        "Sources/ArgumentParser/Validators/CodingKeyValidator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 1131.83,
+      "max_document_chars": 682,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDefinition.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ParserError.swift",
+        "Sources/ArgumentParser/Parsing/Parsed.swift",
+        "Sources/ArgumentParser/Parsable Properties/OptionGroup.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Validators/PositionalArgumentsValidator.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 2143.49,
+      "max_document_chars": 3320,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ArgumentArrayParsingStrategy.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Option.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/OptionGroup.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Flag.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 5350.55,
+      "max_document_chars": 3587,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.4,
+        "known_files": 30,
+        "unique_files": 18
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 6883.76,
+      "max_document_chars": 3587,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.266667,
+        "known_files": 30,
+        "unique_files": 22
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md",
+        "Sources/ArgumentParser/CMakeLists.txt"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 2892.21,
+      "max_document_chars": 682,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.266667,
+        "known_files": 30,
+        "unique_files": 22
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/CMakeLists.txt"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 186.44,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 81.4,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 84.91,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "document_char_budget": 2048,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 102.13,
+      "max_document_chars": 2048,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 2379.86,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry-configurable.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 5371.77,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 4127.94,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "document_char_budget": 706,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 3366.74,
+      "max_document_chars": 706,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 1450.44,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry-configurable.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 11907.56,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 4603.92,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "document_char_budget": 706,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 2511.69,
+      "max_document_chars": 706,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 2882.72,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/errors.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 10489.75,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 5580.72,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "document_char_budget": 706,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 4546.99,
+      "max_document_chars": 706,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/errors.rb"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 371.91,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 105.92,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 98.73,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "document_char_budget": 2048,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 160.07,
+      "max_document_chars": 939,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "document_char_budget": null,
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 1336.35,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/test_interface.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "document_char_budget": null,
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 5571.24,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "document_char_budget": null,
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 6857.41,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "document_char_budget": 682,
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 6483.19,
+      "max_document_chars": 682,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb"
+      ]
+    }
+  ],
+  "repositories": {
+    "attrs": {
+      "content_types": [
+        "code",
+        "markdown",
+        "rst"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 245,
+        "files_processed": 52,
+        "index_ms": 151416.64
+      },
+      "languages": [
+        "python"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/python-attrs/attrs.git",
+      "revision": "d544dd2dacb4cbd660891e323ad92751ba65b4e0"
+    },
+    "dry-configurable": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 30,
+        "files_processed": 16,
+        "index_ms": 6737.47
+      },
+      "languages": [
+        "ruby"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/dry-rb/dry-configurable.git",
+      "revision": "e5e025dfddb481485affe6bb7363d3cf37f153b5"
+    },
+    "fastroute": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 65,
+        "files_processed": 32,
+        "index_ms": 17662.43
+      },
+      "languages": [
+        "php"
+      ],
+      "license": "BSD-3-Clause",
+      "repository_url": "https://github.com/nikic/FastRoute.git",
+      "revision": "1c961398bef1ff6ecd8b273bef651d7afe90312b"
+    },
+    "hono": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 356,
+        "files_processed": 315,
+        "index_ms": 500028.37
+      },
+      "languages": [
+        "typescript",
+        "javascript"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/honojs/hono.git",
+      "revision": "b2ae3a2204a48ce15a26448fd746d39745eb1837"
+    },
+    "pflag": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 1576,
+        "files_processed": 79,
+        "index_ms": 460400.81
+      },
+      "languages": [
+        "go"
+      ],
+      "license": "BSD-3-Clause",
+      "repository_url": "https://github.com/spf13/pflag.git",
+      "revision": "5fdac2d16c16d60605cb8baa887e8c5c38ef623f"
+    },
+    "swift-argument-parser": {
+      "content_types": [
+        "code",
+        "markdown",
+        "docc"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 447,
+        "files_processed": 75,
+        "index_ms": 237342.62
+      },
+      "languages": [
+        "swift"
+      ],
+      "license": "Apache-2.0",
+      "repository_url": "https://github.com/apple/swift-argument-parser.git",
+      "revision": "e579882f95579e7d7eb8c8068a5925c65d361e91"
+    }
+  },
+  "summary": {
+    "candidate_pool": {
+      "current_page_content": {
+        "max_document_chars": 57250,
+        "mean_pool_candidates": 8.6,
+        "mean_pool_duplicate_file_rate": 0.272222,
+        "mean_pool_unique_files": 6.166667,
+        "mean_raw_candidates": 8.6
+      },
+      "expanded_coverage_first_content": {
+        "max_document_chars": 62576,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.183593,
+        "mean_pool_unique_files": 21.766667,
+        "mean_raw_candidates": 92.433333
+      },
+      "expanded_score_order_content": {
+        "max_document_chars": 62576,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.434704,
+        "mean_pool_unique_files": 14.233333,
+        "mean_raw_candidates": 92.433333
+      },
+      "two_stage_structured": {
+        "max_document_chars": 2048,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.183593,
+        "mean_pool_unique_files": 21.766667,
+        "mean_raw_candidates": 92.433333
+      }
+    },
+    "latency": {
+      "current_page_content": {
+        "mean_ms": 1711.15,
+        "p50_ms": 1606.09,
+        "p95_ms": 2824.68
+      },
+      "expanded_coverage_first_content": {
+        "mean_ms": 6074.54,
+        "p50_ms": 5525.08,
+        "p95_ms": 13418.29
+      },
+      "expanded_score_order_content": {
+        "mean_ms": 6334.9,
+        "p50_ms": 5874.14,
+        "p95_ms": 11988.71
+      },
+      "two_stage_structured": {
+        "mean_ms": 2854.62,
+        "p50_ms": 2942.61,
+        "p95_ms": 5824.85
+      }
+    },
+    "paired_macro_mrr": {
+      "expanded_coverage_first_content": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.14246,
+        "ci_upper": 0.056944,
+        "confidence": 0.95,
+        "delta": -0.030238,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.719762,
+        "treatment_engine": "expanded_coverage_first_content"
+      },
+      "expanded_score_order_content": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.047778,
+        "ci_upper": 0.145556,
+        "confidence": 0.95,
+        "delta": 0.04,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.79,
+        "treatment_engine": "expanded_score_order_content"
+      },
+      "two_stage_structured": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.157381,
+        "ci_upper": 0.132778,
+        "confidence": 0.95,
+        "delta": 0.008095,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.758095,
+        "treatment_engine": "two_stage_structured"
+      }
+    },
+    "per_repository": {
+      "attrs": {
+        "current_page_content": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        }
+      },
+      "dry-configurable": {
+        "current_page_content": {
+          "mrr_at_10": 0.716667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.68,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 1.0
+        }
+      },
+      "fastroute": {
+        "current_page_content": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.75,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        }
+      },
+      "hono": {
+        "current_page_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.545238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 0.8
+        }
+      },
+      "pflag": {
+        "current_page_content": {
+          "mrr_at_10": 0.65,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.595238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.833333,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        }
+      },
+      "swift-argument-parser": {
+        "current_page_content": {
+          "mrr_at_10": 0.766667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.491667,
+          "queries_supported": 5,
+          "top_1": 0.2,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.633333,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.74,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        }
+      }
+    },
+    "pooled": {
+      "current_page_content": {
+        "mrr_at_10": 0.75,
+        "queries_supported": 30,
+        "top_1": 0.6,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.966667
+      },
+      "expanded_coverage_first_content": {
+        "mrr_at_10": 0.719762,
+        "queries_supported": 30,
+        "top_1": 0.566667,
+        "top_10": 1.0,
+        "top_3": 0.866667,
+        "top_5": 0.9
+      },
+      "expanded_score_order_content": {
+        "mrr_at_10": 0.79,
+        "queries_supported": 30,
+        "top_1": 0.666667,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.933333
+      },
+      "two_stage_structured": {
+        "mrr_at_10": 0.758095,
+        "queries_supported": 30,
+        "top_1": 0.666667,
+        "top_10": 1.0,
+        "top_3": 0.766667,
+        "top_5": 0.933333
+      }
+    },
+    "predeclared_gates": {
+      "added_p95_at_most_300_ms": false,
+      "macro_mrr_non_negative": true,
+      "max_document_chars_enforced": true,
+      "passed": false,
+      "treatment_p95_at_most_500_ms": false
+    },
+    "primary_macro_per_repository": {
+      "current_page_content": {
+        "mrr_at_10": 0.75,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 0.866667,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.716667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.6,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 0.8,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.65,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.766667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.6,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.966667
+      },
+      "expanded_coverage_first_content": {
+        "mrr_at_10": 0.719762,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.706667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.625,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.595238,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.491667,
+            "queries_supported": 5,
+            "top_1": 0.2,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.566667,
+        "top_10": 1.0,
+        "top_3": 0.866667,
+        "top_5": 0.9
+      },
+      "expanded_score_order_content": {
+        "mrr_at_10": 0.79,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.706667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.6,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 0.8,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.633333,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.666667,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.933333
+      },
+      "two_stage_structured": {
+        "mrr_at_10": 0.758095,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.68,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.6,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.75,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "hono": {
+            "mrr_at_10": 0.545238,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.6,
+            "top_5": 0.8
+          },
+          "pflag": {
+            "mrr_at_10": 0.833333,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.74,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.666667,
+        "top_10": 1.0,
+        "top_3": 0.766667,
+        "top_5": 0.933333
+      }
+    },
+    "protected_segments": {
+      "content_type": {
+        "current_page_content/code": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 18,
+          "top_1": 0.388889,
+          "top_10": 0.944444,
+          "top_3": 0.888889,
+          "top_5": 0.944444
+        },
+        "current_page_content/document": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 6,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/mixed": {
+          "mrr_at_10": 0.875,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/code": {
+          "mrr_at_10": 0.605159,
+          "queries_supported": 18,
+          "top_1": 0.388889,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 0.833333
+        },
+        "expanded_coverage_first_content/document": {
+          "mrr_at_10": 0.916667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/mixed": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/code": {
+          "mrr_at_10": 0.722222,
+          "queries_supported": 18,
+          "top_1": 0.555556,
+          "top_10": 0.944444,
+          "top_3": 0.888889,
+          "top_5": 0.888889
+        },
+        "expanded_score_order_content/document": {
+          "mrr_at_10": 0.916667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/mixed": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "two_stage_structured/code": {
+          "mrr_at_10": 0.688889,
+          "queries_supported": 18,
+          "top_1": 0.555556,
+          "top_10": 1.0,
+          "top_3": 0.722222,
+          "top_5": 0.944444
+        },
+        "two_stage_structured/document": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 6,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/mixed": {
+          "mrr_at_10": 0.72381,
+          "queries_supported": 6,
+          "top_1": 0.666667,
+          "top_10": 1.0,
+          "top_3": 0.666667,
+          "top_5": 0.833333
+        }
+      },
+      "language": {
+        "current_page_content/go": {
+          "mrr_at_10": 0.65,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "current_page_content/php": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "current_page_content/python": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/ruby": {
+          "mrr_at_10": 0.716667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "current_page_content/swift": {
+          "mrr_at_10": 0.766667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/go": {
+          "mrr_at_10": 0.595238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/php": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/ruby": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/swift": {
+          "mrr_at_10": 0.491667,
+          "queries_supported": 5,
+          "top_1": 0.2,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/go": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/php": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/ruby": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/swift": {
+          "mrr_at_10": 0.633333,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/go": {
+          "mrr_at_10": 0.833333,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured/php": {
+          "mrr_at_10": 0.75,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "two_stage_structured/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/ruby": {
+          "mrr_at_10": 0.68,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 1.0
+        },
+        "two_stage_structured/swift": {
+          "mrr_at_10": 0.74,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "two_stage_structured/typescript": {
+          "mrr_at_10": 0.545238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 0.8
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/development-two-stage-initial-2026-07-14.json
+++ b/benchmarks/development-two-stage-initial-2026-07-14.json
@@ -1,0 +1,6251 @@
+{
+  "limitations": [
+    "This is a public development treatment, not a sealed holdout result.",
+    "File-level labels do not score snippet usefulness, answer synthesis, or agent task completion.",
+    "The four stages diagnose one predeclared mechanism; they are not a model or pool-size sweep.",
+    "Segment samples are small and are reported as guardrails rather than tuning targets."
+  ],
+  "metadata": {
+    "command": [
+      "scripts/benchmark_two_stage.py",
+      "--tier",
+      "quick",
+      "--output",
+      "benchmarks/development-two-stage-2026-07-14.json"
+    ],
+    "embedding_model": "BAAI/bge-small-en-v1.5",
+    "engine_order_rotated": true,
+    "evaluation_split": "development",
+    "generated_at": "2026-07-14T09:39:08.819016+00:00",
+    "manifest_path": "benchmarks/corpora/v1/manifest.yaml",
+    "manifest_schema_version": 1,
+    "manifest_sha256": "0e84423ee5f116554af104908b0ba845cee25bc69bfecc38cb813e3deab1c701",
+    "max_document_chars": 4096,
+    "max_pool_size": 50,
+    "max_raw_fetch_size": 250,
+    "platform": "macOS-15.5-arm64-arm-64bit-Mach-O",
+    "pool_multiplier": 3,
+    "python": "3.14.3",
+    "query_cases": 30,
+    "random_seed": 1729,
+    "raw_fetch_multiplier": 5,
+    "repository_revisions": {
+      "attrs": "d544dd2dacb4cbd660891e323ad92751ba65b4e0",
+      "dry-configurable": "e5e025dfddb481485affe6bb7363d3cf37f153b5",
+      "fastroute": "1c961398bef1ff6ecd8b273bef651d7afe90312b",
+      "hono": "b2ae3a2204a48ce15a26448fd746d39745eb1837",
+      "pflag": "5fdac2d16c16d60605cb8baa887e8c5c38ef623f",
+      "swift-argument-parser": "e579882f95579e7d7eb8c8068a5925c65d361e91"
+    },
+    "reranking_model": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "selection_allowed": true,
+    "tessera_revision": "c36c093883909945d0e5f2418e7664ffacfe8473",
+    "tier": "quick",
+    "top_k": 10
+  },
+  "queries": [
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 751.78,
+      "max_document_chars": 4343,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_make.py",
+        "src/attr/validators.py",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 2030.68,
+      "max_document_chars": 9396,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.733333,
+        "known_files": 30,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_funcs.py",
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 2297.48,
+      "max_document_chars": 7801,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "src/attr/validators.py",
+        "src/attrs/__init__.py",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-converter-pipeline",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find optional and piped value converters",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/converters.py"
+      ],
+      "id": "attrs-converter-pipeline",
+      "language": "python",
+      "latency_ms": 2755.63,
+      "max_document_chars": 4096,
+      "query": "normalize optional attribute values through a converter pipeline",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/converters.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "src/attrs/__init__.py",
+        "src/attr/validators.py",
+        "src/attr/setters.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 688.74,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py",
+        "src/attr/__init__.py",
+        "src/attr/_make.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 2692.58,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.766667,
+        "known_files": 30,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 2021.04,
+      "max_document_chars": 7076,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/converters.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-deep-validators",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find deep iterable and optional validators",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/validators.py"
+      ],
+      "id": "attrs-deep-validators",
+      "language": "python",
+      "latency_ms": 4028.84,
+      "max_document_chars": 4096,
+      "query": "validate every item in a nested iterable and allow optional values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/validators.py",
+        "src/attr/_next_gen.py",
+        "src/attr/setters.py",
+        "src/attr/converters.py",
+        "src/attrs/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 590.96,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.6,
+        "known_files": 10,
+        "unique_files": 4
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_make.py",
+        "src/attr/_compat.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 2207.72,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.766667,
+        "known_files": 30,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_cmp.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 2132.56,
+      "max_document_chars": 20352,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_funcs.py",
+        "src/attr/_cmp.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-generated-init",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find generated initializer implementation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-generated-init",
+      "language": "python",
+      "latency_ms": 1835.43,
+      "max_document_chars": 4096,
+      "query": "generate init methods and attach them to decorated classes",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.866667,
+        "known_files": 150,
+        "unique_files": 20
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/attr/_make.py",
+        "src/attr/_funcs.py",
+        "src/attr/_next_gen.py",
+        "src/attr/_compat.py",
+        "src/attr/_cmp.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 668.95,
+      "max_document_chars": 3507,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/index.md",
+        "docs/api.rst",
+        "docs/api-attr.rst"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 1990.96,
+      "max_document_chars": 3533,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.5,
+        "known_files": 30,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/types.md",
+        "docs/how-does-it-work.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/extending.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 7374.25,
+      "max_document_chars": 3533,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.433333,
+        "known_files": 30,
+        "unique_files": 17
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/types.md",
+        "docs/how-does-it-work.md",
+        "docs/overview.md",
+        "docs/examples.md",
+        "docs/extending.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-dataclasses-comparison",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the attrs and dataclasses comparison",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/why.md"
+      ],
+      "id": "attrs-dataclasses-comparison",
+      "language": "python",
+      "latency_ms": 2105.44,
+      "max_document_chars": 3653,
+      "query": "why use attrs instead of standard library dataclasses",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 83,
+        "duplicate_file_rate": 0.795181,
+        "known_files": 83,
+        "unique_files": 17
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.433333,
+        "known_files": 30,
+        "unique_files": 17
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/why.md",
+        "docs/names.md",
+        "docs/overview.md",
+        "docs/types.md",
+        "docs/how-does-it-work.md",
+        "docs/extending.md",
+        "docs/glossary.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 1864.4,
+      "max_document_chars": 9764,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.4,
+        "known_files": 10,
+        "unique_files": 6
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.4,
+        "known_files": 10,
+        "unique_files": 6
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_make.py",
+        "docs/api.rst",
+        "docs/index.md",
+        "src/attr/validators.py",
+        "src/attr/setters.py"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 7204.45,
+      "max_document_chars": 16826,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.6,
+        "known_files": 30,
+        "unique_files": 12
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_next_gen.py",
+        "src/attr/_make.py",
+        "docs/examples.md",
+        "README.md",
+        "docs/api.rst"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 12852.15,
+      "max_document_chars": 7076,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_next_gen.py",
+        "README.md",
+        "docs/api.rst",
+        "src/attr/_make.py",
+        "docs/how-does-it-work.md",
+        "docs/api-attr.rst",
+        "docs/extending.md",
+        "docs/index.md",
+        "docs/examples.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "attrs-init-lifecycle",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find initialization lifecycle documentation or implementation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/init.md",
+        "src/attr/_make.py"
+      ],
+      "id": "attrs-init-lifecycle",
+      "language": "python",
+      "latency_ms": 10646.48,
+      "max_document_chars": 4096,
+      "query": "how generated initialization orders converters validators and post init hooks",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.793333,
+        "known_files": 150,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "attrs",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/init.md",
+        "src/attr/_next_gen.py",
+        "README.md",
+        "docs/api.rst",
+        "docs/examples.md",
+        "src/attrs/__init__.py",
+        "docs/api-attr.rst",
+        "src/attr/_make.py",
+        "docs/extending.md",
+        "src/attr/__init__.py"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 5201.48,
+      "max_document_chars": 20131,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/serve-static/index.ts",
+        "src/request.test.ts",
+        "src/client/client.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 20542.83,
+      "max_document_chars": 62576,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.133333,
+        "known_files": 30,
+        "unique_files": 26
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/trailing-slash/index.test.ts",
+        "src/middleware/context-storage/index.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 11352.37,
+      "max_document_chars": 62576,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/trailing-slash/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/trailing-slash/index.test.ts",
+        "src/middleware/context-storage/index.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-compose-middleware",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find middleware composition",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/compose.ts"
+      ],
+      "id": "hono-compose-middleware",
+      "language": "typescript",
+      "latency_ms": 11756.17,
+      "max_document_chars": 4096,
+      "query": "compose middleware into a request dispatch chain and call next",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.04,
+        "known_files": 150,
+        "unique_files": 144
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/compose.ts",
+        "src/middleware/combine/index.test.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/compose.test.ts",
+        "src/middleware/combine/index.ts",
+        "src/middleware/context-storage/index.ts",
+        "src/helper/dev/index.test.ts",
+        "src/middleware/request-id/index.test.ts",
+        "src/middleware/trailing-slash/index.test.ts",
+        "src/middleware/pretty-json/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 664.68,
+      "max_document_chars": 18499,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/client/client.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/middleware/language/language.ts",
+        "src/middleware/jwk/jwk.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 1836.55,
+      "max_document_chars": 57250,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/client/client.ts",
+        "src/adapter/aws-lambda/handler.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 17732.25,
+      "max_document_chars": 57250,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/helper/cookie/index.ts",
+        "src/utils/cookie.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/client/client.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/middleware/language/language.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-signed-cookies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find signed cookie helpers",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts"
+      ],
+      "id": "hono-signed-cookies",
+      "language": "typescript",
+      "latency_ms": 4871.21,
+      "max_document_chars": 4096,
+      "query": "parse verify and serialize HMAC signed cookies",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.08,
+        "known_files": 150,
+        "unique_files": 138
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/utils/cookie.test.ts",
+        "src/utils/jwt/jws.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/utils/cookie.ts",
+        "src/helper/cookie/index.ts",
+        "src/helper/cookie/index.test.ts",
+        "src/middleware/jwk/index.test.ts",
+        "src/client/client.ts",
+        "src/middleware/language/language.ts",
+        "src/validator/validator.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 674.84,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/index.test.ts",
+        "src/client/client.test.ts",
+        "src/utils/basic-auth.ts",
+        "src/utils/headers.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 2054.75,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/csrf/index.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/adapter/aws-lambda/conninfo.test.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 1768.48,
+      "max_document_chars": 57250,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/middleware/jwk/jwk.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/csrf/index.ts",
+        "src/middleware/bearer-auth/index.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/adapter/aws-lambda/conninfo.test.ts",
+        "src/middleware/request-id/index.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-basic-auth",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find basic authentication middleware",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/middleware/basic-auth/index.ts"
+      ],
+      "id": "hono-basic-auth",
+      "language": "typescript",
+      "latency_ms": 2041.39,
+      "max_document_chars": 4096,
+      "query": "HTTP basic authentication middleware validates username and password",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/middleware/basic-auth/index.ts",
+        "src/middleware/basic-auth/index.test.ts",
+        "src/utils/basic-auth.test.ts",
+        "src/utils/basic-auth.ts",
+        "src/middleware/jwt/jwt.ts",
+        "src/middleware/request-id/request-id.ts",
+        "src/middleware/bearer-auth/index.test.ts",
+        "src/middleware/jwt/index.test.ts",
+        "src/validator/validator.ts",
+        "src/adapter/aws-lambda/conninfo.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "engine": "current_page_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 87.8,
+      "max_document_chars": 3330,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 736.51,
+      "max_document_chars": 3530,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 729.55,
+      "max_document_chars": 3530,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-migration",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find the migration guide",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "docs/MIGRATION.md"
+      ],
+      "id": "hono-migration",
+      "language": "typescript",
+      "latency_ms": 1131.21,
+      "max_document_chars": 3673,
+      "query": "migrate an application across breaking Hono releases",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "docs/MIGRATION.md",
+        "docs/CONTRIBUTING.md",
+        "README.md",
+        "src/middleware/jwk/keys.test.json",
+        "docs/CODE_OF_CONDUCT.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 727.71,
+      "max_document_chars": 30906,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/helper/streaming/stream.test.ts",
+        "src/jsx/streaming.test.tsx",
+        "src/helper/streaming/stream.ts",
+        "src/utils/stream.test.ts",
+        "src/utils/stream.ts",
+        "src/adapter/service-worker/types.ts",
+        "src/helper/streaming/text.test.ts",
+        "src/client/utils.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 12607.98,
+      "max_document_chars": 46036,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.066667,
+        "known_files": 30,
+        "unique_files": 28
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/adapter/bun/websocket.test.ts",
+        "src/helper/websocket/index.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/hono-base.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/websocket/index.test.ts",
+        "src/helper/streaming/stream.test.ts",
+        "src/jsx/streaming.test.tsx"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 2537.63,
+      "max_document_chars": 46036,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/adapter/bun/websocket.test.ts",
+        "src/helper/websocket/index.ts",
+        "src/adapter/deno/websocket.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/hono-base.ts",
+        "src/adapter/aws-lambda/handler.test.ts",
+        "src/helper/websocket/index.test.ts",
+        "src/helper/streaming/stream.test.ts"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "hono-server-sent-events",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find the server-sent event streaming API",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/index.ts"
+      ],
+      "id": "hono-server-sent-events",
+      "language": "typescript",
+      "latency_ms": 1931.18,
+      "max_document_chars": 4096,
+      "query": "stream server sent events with event data ids and retry intervals",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.06,
+        "known_files": 150,
+        "unique_files": 141
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "hono",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/helper/streaming/sse.ts",
+        "src/helper/streaming/sse.test.tsx",
+        "src/helper/websocket/index.test.ts",
+        "src/helper/websocket/index.ts",
+        "src/adapter/bun/websocket.test.ts",
+        "src/adapter/deno/websocket.ts",
+        "src/adapter/cloudflare-pages/handler.test.ts",
+        "src/hono-base.ts",
+        "src/helper/streaming/stream.test.ts",
+        "src/helper/streaming/stream.ts"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 543.44,
+      "max_document_chars": 3724,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/Route.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/DataGenerator/GroupPosBased.php",
+        "src/DataGenerator/CharCountBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/DataGenerator/MarkBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 1892.87,
+      "max_document_chars": 3819,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.333333,
+        "known_files": 30,
+        "unique_files": 20
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/ConfigureRoutes.php",
+        "src/GenerateUri.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 2403.51,
+      "max_document_chars": 3819,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/ConfigureRoutes.php",
+        "src/BadRouteException.php",
+        "src/GenerateUri.php",
+        "src/Route.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/functions.php",
+        "src/DataGenerator.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-route-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find standard route parsing",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/RouteParser/Std.php"
+      ],
+      "id": "fastroute-route-parser",
+      "language": "php",
+      "latency_ms": 1713.39,
+      "max_document_chars": 4096,
+      "query": "parse route placeholders regular expressions and optional trailing segments",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/RouteParser/Std.php",
+        "src/RouteParser.php",
+        "src/RouteCollector.php",
+        "src/BadRouteException.php",
+        "src/Route.php",
+        "src/ConfigureRoutes.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/functions.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 633.03,
+      "max_document_chars": 3401,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": null,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 0.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Dispatcher/Result/Matched.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 1835.24,
+      "max_document_chars": 3819,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": null,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.3,
+        "known_files": 30,
+        "unique_files": 21
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/RouteParser/Std.php",
+        "src/Dispatcher/CharCountBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 1996.21,
+      "max_document_chars": 5337,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": 8,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.125,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/RouteParser/Std.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/Result/MethodNotAllowed.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Dispatcher/Result/Matched.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-method-not-allowed",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find method-not-allowed dispatch results",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/Dispatcher/Result/MethodNotAllowed.php"
+      ],
+      "id": "fastroute-method-not-allowed",
+      "language": "php",
+      "latency_ms": 1718.39,
+      "max_document_chars": 4096,
+      "query": "represent a dispatch result when the path matches but HTTP method does not",
+      "rank": 7,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.142857,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Dispatcher.php",
+        "src/Dispatcher/Result/Matched.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/Result/MethodNotAllowed.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/Result/NotMatched.php",
+        "src/Route.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "engine": "current_page_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 636.63,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteCollector.php",
+        "src/Cache/Psr16Cache.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Cache.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 2047.08,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.233333,
+        "known_files": 30,
+        "unique_files": 23
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteParser/Std.php",
+        "src/RouteCollector.php",
+        "src/RouteParser.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 2136.55,
+      "max_document_chars": 5337,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/FastRoute.php",
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/DataGenerator.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/RouteParser/Std.php",
+        "src/GenerateUri.php",
+        "src/RouteCollector.php",
+        "src/RouteParser.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-file-cache",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the filesystem route cache",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "src/Cache/FileCache.php"
+      ],
+      "id": "fastroute-file-cache",
+      "language": "php",
+      "latency_ms": 1984.5,
+      "max_document_chars": 4096,
+      "query": "persist generated route collector data in a filesystem cache",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 61,
+        "duplicate_file_rate": 0.491803,
+        "known_files": 61,
+        "unique_files": 31
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "src/Cache/FileCache.php",
+        "src/functions.php",
+        "src/FastRoute.php",
+        "src/DataGenerator/RegexBasedAbstract.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/GenerateUri.php",
+        "src/RouteParser/Std.php",
+        "src/Cache/Psr16Cache.php",
+        "src/DataGenerator.php"
+      ]
+    },
+    {
+      "candidate_budget": 3,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 190.02,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 3,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 3,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 3,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 3,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 277.27,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 301.3,
+      "max_document_chars": 3553,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 4,
+      "case_id": "fastroute-route-groups",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find route group documentation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "fastroute-route-groups",
+      "language": "php",
+      "latency_ms": 229.48,
+      "max_document_chars": 3664,
+      "query": "define route groups with a shared path prefix",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 4,
+        "duplicate_file_rate": 0.75,
+        "known_files": 4,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 690.94,
+      "max_document_chars": 3553,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/Dispatcher/CharCountBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/RegexBasedAbstract.php",
+        "src/Route.php",
+        "src/DataGenerator/MarkBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 2309.05,
+      "max_document_chars": 3819,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.3,
+        "known_files": 30,
+        "unique_files": 21
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/RouteParser.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/RouteCollector.php",
+        "src/ConfigureRoutes.php",
+        "src/RouteParser/Std.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 1840.82,
+      "max_document_chars": 3819,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/RouteParser.php",
+        "src/GenerateUri.php",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/RouteCollector.php",
+        "src/BadRouteException.php",
+        "src/ConfigureRoutes.php",
+        "src/Dispatcher/GroupCountBased.php",
+        "src/Dispatcher/CharCountBased.php"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "fastroute-uri-generation",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find URI generation usage or implementation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "src/GenerateUri/FromProcessedConfiguration.php"
+      ],
+      "id": "fastroute-uri-generation",
+      "language": "php",
+      "latency_ms": 2145.4,
+      "max_document_chars": 4096,
+      "query": "generate a URI from a named route and placeholder values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 65,
+        "duplicate_file_rate": 0.507692,
+        "known_files": 65,
+        "unique_files": 32
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "fastroute",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "src/GenerateUri/UriCouldNotBeGenerated.php",
+        "src/GenerateUri/FromProcessedConfiguration.php",
+        "src/RouteParser.php",
+        "src/GenerateUri.php",
+        "src/RouteCollector.php",
+        "src/BadRouteException.php",
+        "src/Dispatcher/GroupPosBased.php",
+        "src/Dispatcher/MarkBased.php",
+        "src/Dispatcher/RegexBasedAbstract.php"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "engine": "current_page_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 913.54,
+      "max_document_chars": 1376,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "flag.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 2634.28,
+      "max_document_chars": 4013,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.7,
+        "known_files": 30,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 2343.34,
+      "max_document_chars": 4444,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "string_slice.go",
+        "flag_test.go",
+        "flag.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "errors.go",
+        "golangflag.go",
+        "bool_test.go",
+        "bytes.go",
+        "string.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-name-normalization",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find custom flag-name normalization",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-name-normalization",
+      "language": "go",
+      "latency_ms": 3193.98,
+      "max_document_chars": 4096,
+      "query": "normalize flag names so underscores and hyphens compare as equivalent",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.7,
+        "known_files": 150,
+        "unique_files": 45
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "flag_test.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "bytes.go",
+        "errors.go",
+        "golangflag.go",
+        "string.go",
+        "bool.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "engine": "current_page_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 643.94,
+      "max_document_chars": 7053,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "flag.go",
+        "bool.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 1960.33,
+      "max_document_chars": 7053,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.633333,
+        "known_files": 30,
+        "unique_files": 11
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 2074.84,
+      "max_document_chars": 4444,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 7,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.142857,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "bool_func_go1.21_test.go",
+        "string_to_string.go",
+        "example_test.go",
+        "bool_slice_test.go",
+        "string_to_string_test.go",
+        "flag.go",
+        "errors.go",
+        "bytes.go",
+        "bool_func.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-shorthand-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find shorthand flag parsing",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "flag.go"
+      ],
+      "id": "pflag-shorthand-parser",
+      "language": "go",
+      "latency_ms": 1945.74,
+      "max_document_chars": 4096,
+      "query": "parse combined single-letter shorthand boolean flags",
+      "rank": 7,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.142857,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag_test.go",
+        "bool_func_go1.21_test.go",
+        "string_to_string.go",
+        "bool_slice_test.go",
+        "example_test.go",
+        "string_to_string_test.go",
+        "flag.go",
+        "bool_test.go",
+        "bytes.go",
+        "bool_slice.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "engine": "current_page_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 476.44,
+      "max_document_chars": 1039,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.3,
+        "known_files": 10,
+        "unique_files": 7
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "bytes.go",
+        "flag_test.go",
+        "ipnet_slice_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 2021.3,
+      "max_document_chars": 4444,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "bytes.go",
+        "golangflag.go",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 2339.29,
+      "max_document_chars": 4444,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "string_slice.go",
+        "string_to_string.go",
+        "errors.go",
+        "uint_slice_test.go",
+        "bytes.go",
+        "duration_slice_test.go",
+        "golangflag.go",
+        "string_slice_test.go",
+        "string_array_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-string-slice",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find string-slice flags",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "string_slice.go"
+      ],
+      "id": "pflag-string-slice",
+      "language": "go",
+      "latency_ms": 2129.76,
+      "max_document_chars": 4096,
+      "query": "implement a repeatable string slice command line flag value",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.646667,
+        "known_files": 150,
+        "unique_files": 53
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "string_slice.go",
+        "flag.go",
+        "string_to_string.go",
+        "string_slice_test.go",
+        "uint_slice_test.go",
+        "uint_slice.go",
+        "int32_slice.go",
+        "int64_slice.go",
+        "duration_slice_test.go",
+        "float32_slice.go"
+      ]
+    },
+    {
+      "candidate_budget": 2,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 244.86,
+      "max_document_chars": 3464,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 2,
+        "duplicate_file_rate": 0.5,
+        "known_files": 2,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 2,
+        "duplicate_file_rate": 0.5,
+        "known_files": 2,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 928.16,
+      "max_document_chars": 3476,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 1652.76,
+      "max_document_chars": 3476,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 14,
+      "case_id": "pflag-go-flag-compatibility",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find standard flag compatibility documentation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "pflag-go-flag-compatibility",
+      "language": "go",
+      "latency_ms": 1465.72,
+      "max_document_chars": 3605,
+      "query": "use pflag together with the standard library flag package",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 14,
+        "duplicate_file_rate": 0.642857,
+        "known_files": 14,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "RELEASING.md",
+        ".golangci.yaml",
+        ".editorconfig",
+        ".travis.yml"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 913.52,
+      "max_document_chars": 3476,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "errors.go",
+        "flag_test.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 2022.74,
+      "max_document_chars": 4013,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 30,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "flag_test.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 2143.06,
+      "max_document_chars": 3476,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "flag.go",
+        "README.md",
+        "example_test.go",
+        "errors.go",
+        "flag_test.go",
+        "bool_func_test.go",
+        "func_test.go",
+        "golangflag.go",
+        "bool.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "pflag-deprecated-shorthand",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find shorthand deprecation behavior",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "flag.go"
+      ],
+      "id": "pflag-deprecated-shorthand",
+      "language": "go",
+      "latency_ms": 2853.22,
+      "max_document_chars": 3605,
+      "query": "deprecate a flag shorthand hide it from help and print a warning",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.666667,
+        "known_files": 150,
+        "unique_files": 50
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "pflag",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md",
+        "flag.go",
+        "example_test.go",
+        "bool_func_test.go",
+        "errors.go",
+        "func_test.go",
+        "flag_test.go",
+        "bool.go",
+        "ipnet.go",
+        "bytes.go"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 841.77,
+      "max_document_chars": 11728,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/ParentCommand.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 2178.26,
+      "max_document_chars": 18364,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 2414.69,
+      "max_document_chars": 18364,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandGroup.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/Errors.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-command-parser",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find subcommand parsing",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift"
+      ],
+      "id": "swift-command-parser",
+      "language": "swift",
+      "latency_ms": 2046.98,
+      "max_document_chars": 4096,
+      "query": "parse nested subcommands and select the matching command configuration",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.713333,
+        "known_files": 150,
+        "unique_files": 43
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentSet.swift",
+        "Sources/ArgumentParser/Utilities/Tree.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandGroup.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableArguments.swift",
+        "Sources/ArgumentParser/Usage/MessageInfo.swift",
+        "Sources/ArgumentParser/Parsable Properties/Errors.swift",
+        "Sources/ArgumentParser/Parsable Types/CommandConfiguration.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 4667.74,
+      "max_document_chars": 13431,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.7,
+        "known_files": 10,
+        "unique_files": 3
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 2489.12,
+      "max_document_chars": 13431,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 6,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.166667,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.5,
+        "known_files": 30,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 2904.83,
+      "max_document_chars": 8947,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 8,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.125,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Usage/HelpGenerator.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-bash-completions",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find Bash completion generation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift"
+      ],
+      "id": "swift-bash-completions",
+      "language": "swift",
+      "latency_ms": 4972.99,
+      "max_document_chars": 4096,
+      "query": "generate bash completion functions for options arguments and subcommands",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.72,
+        "known_files": 150,
+        "unique_files": 42
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/FishCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsing/CommandParser.swift",
+        "Sources/ArgumentParser/Parsable Properties/CompletionKind.swift",
+        "Sources/ArgumentParser/Usage/HelpCommand.swift",
+        "Sources/ArgumentParser/Usage/DumpHelpGenerator.swift",
+        "Sources/ArgumentParser/Completions/ZshCompletionsGenerator.swift",
+        "Sources/ArgumentParser/Parsable Types/ParsableCommand.swift",
+        "Sources/ArgumentParser/Parsing/ParserError.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 1368.97,
+      "max_document_chars": 6714,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.5,
+        "known_files": 10,
+        "unique_files": 5
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsable Properties/OptionGroup.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDecoder.swift",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 3497.25,
+      "max_document_chars": 6714,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.533333,
+        "known_files": 30,
+        "unique_files": 14
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDecoder.swift",
+        "Sources/ArgumentParser/Parsing/Parsed.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 6029.94,
+      "max_document_chars": 8088,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Validators/PositionalArgumentsValidator.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift",
+        "Sources/ArgumentParser/Validators/UniqueNamesValidator.swift",
+        "Sources/ArgumentParser/Utilities/SequenceExtensions.swift",
+        "Sources/ArgumentParser/Parsable Properties/OptionGroup.swift",
+        "Sources/ArgumentParser/Validators/CodingKeyValidator.swift"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-option-strategies",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find option parsing strategies",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift"
+      ],
+      "id": "swift-option-strategies",
+      "language": "swift",
+      "latency_ms": 3275.17,
+      "max_document_chars": 4096,
+      "query": "configure option parsing strategies for arrays and repeated values",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 150,
+        "duplicate_file_rate": 0.76,
+        "known_files": 150,
+        "unique_files": 36
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.0,
+        "known_files": 30,
+        "unique_files": 30
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Parsable Properties/Option.swift",
+        "Sources/ArgumentParser/Parsable Properties/Argument.swift",
+        "Sources/ArgumentParser/Validators/PositionalArgumentsValidator.swift",
+        "Sources/ArgumentParser/Parsing/SplitArguments.swift",
+        "Sources/ArgumentParser/Parsing/InputOrigin.swift",
+        "Sources/ArgumentParser/Parsing/ParserError.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDefinition.swift",
+        "Sources/ArgumentParser/Parsing/ParsedValues.swift",
+        "Sources/ArgumentParser/Usage/UsageGenerator.swift",
+        "Sources/ArgumentParser/Parsing/ArgumentDecoder.swift"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 1157.04,
+      "max_document_chars": 3320,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.0,
+        "known_files": 10,
+        "unique_files": 10
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ArgumentArrayParsingStrategy.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Argument.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Option.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/CommandConfiguration.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/OptionGroup.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/Flag.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 2886.23,
+      "max_document_chars": 3587,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.4,
+        "known_files": 30,
+        "unique_files": 18
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 2135.37,
+      "max_document_chars": 3587,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.266667,
+        "known_files": 30,
+        "unique_files": 22
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md",
+        "Sources/ArgumentParser/CMakeLists.txt"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "swift-validation-guide",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find argument validation documentation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md"
+      ],
+      "id": "swift-validation-guide",
+      "language": "swift",
+      "latency_ms": 3822.01,
+      "max_document_chars": 3772,
+      "query": "validate parsed command line arguments and report validation errors",
+      "rank": 2,
+      "raw_candidates": {
+        "candidates": 45,
+        "duplicate_file_rate": 0.511111,
+        "known_files": 45,
+        "unique_files": 22
+      },
+      "reciprocal_rank": 0.5,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.266667,
+        "known_files": 30,
+        "unique_files": 22
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/ManualParsing.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/Validation.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableArguments.md",
+        "Sources/ArgumentParser/Documentation.docc/Articles/DeclaringArguments.md",
+        "README.md",
+        "Sources/ArgumentParser/Documentation.docc/Extensions/ParsableCommand.md",
+        "Sources/ArgumentParser/Documentation.docc/ArgumentParser.md",
+        "Sources/ArgumentParser/CMakeLists.txt"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 222.96,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 128.13,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 111.07,
+      "max_document_chars": 2084,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "swift-completion-install",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find completion installation documentation or implementation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md",
+        "Sources/ArgumentParser/Completions/CompletionsGenerator.swift"
+      ],
+      "id": "swift-completion-install",
+      "language": "swift",
+      "latency_ms": 83.2,
+      "max_document_chars": 2285,
+      "query": "generate and install shell completion scripts for a command",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "swift-argument-parser",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 1503.31,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.2,
+        "known_files": 10,
+        "unique_files": 8
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry-configurable.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 2553.33,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 2454.09,
+      "max_document_chars": 7651,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-compiler",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find the configuration DSL compiler",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/compiler.rb"
+      ],
+      "id": "dry-configurable-compiler",
+      "language": "ruby",
+      "latency_ms": 2418.1,
+      "max_document_chars": 4096,
+      "query": "compile nested setting abstract syntax tree nodes into configuration settings",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 580.16,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry-configurable.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 1824.4,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 2754.29,
+      "max_document_chars": 7651,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 3,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.333333,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-finalize",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configuration finalization",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/config.rb"
+      ],
+      "id": "dry-configurable-finalize",
+      "language": "ruby",
+      "latency_ms": 1948.08,
+      "max_document_chars": 4096,
+      "query": "finalize a configuration recursively and prevent later mutation",
+      "rank": 6,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 0.166667,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "engine": "current_page_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 692.86,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/errors.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 2381.69,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 2737.54,
+      "max_document_chars": 7651,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 29,
+      "case_id": "dry-configurable-inheritance",
+      "category": "code",
+      "content_type": "code",
+      "description": "Find configurable class inheritance",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "lib/dry/configurable/class_methods.rb"
+      ],
+      "id": "dry-configurable-inheritance",
+      "language": "ruby",
+      "latency_ms": 1736.48,
+      "max_document_chars": 4096,
+      "query": "duplicate settings and configuration values when a configurable class is inherited",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 29,
+        "duplicate_file_rate": 0.482759,
+        "known_files": 29,
+        "unique_files": 15
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/test_interface.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable/methods.rb"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 215.63,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 65.26,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 39.81,
+      "max_document_chars": 830,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 1,
+      "case_id": "dry-configurable-nested-settings",
+      "category": "document",
+      "content_type": "document",
+      "description": "Find nested configuration documentation",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md"
+      ],
+      "id": "dry-configurable-nested-settings",
+      "language": "ruby",
+      "latency_ms": 51.34,
+      "max_document_chars": 939,
+      "query": "define nested settings with defaults and constructors",
+      "rank": 1,
+      "raw_candidates": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "reciprocal_rank": 1.0,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 1,
+        "duplicate_file_rate": 0.0,
+        "known_files": 1,
+        "unique_files": 1
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "README.md"
+      ]
+    },
+    {
+      "candidate_budget": 10,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "engine": "current_page_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 910.18,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 10,
+      "rerank_pool": {
+        "candidates": 10,
+        "duplicate_file_rate": 0.1,
+        "known_files": 10,
+        "unique_files": 9
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/test_interface.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "engine": "expanded_score_order_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 1780.33,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "engine": "expanded_coverage_first_content",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 2473.82,
+      "max_document_chars": 7651,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 5,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.2,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/compiler.rb"
+      ]
+    },
+    {
+      "candidate_budget": 30,
+      "case_id": "dry-configurable-class-and-instance",
+      "category": "cross",
+      "content_type": "mixed",
+      "description": "Find class and instance configuration behavior",
+      "engine": "two_stage_structured",
+      "expected_files": [
+        "README.md",
+        "lib/dry/configurable/extension.rb",
+        "lib/dry/configurable/instance_methods.rb"
+      ],
+      "id": "dry-configurable-class-and-instance",
+      "language": "ruby",
+      "latency_ms": 1705.46,
+      "max_document_chars": 4096,
+      "query": "expose the same configurable settings on classes and instances",
+      "rank": 4,
+      "raw_candidates": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "reciprocal_rank": 0.25,
+      "repository": "dry-configurable",
+      "requested_retrieval_budget": 150,
+      "rerank_pool": {
+        "candidates": 30,
+        "duplicate_file_rate": 0.466667,
+        "known_files": 30,
+        "unique_files": 16
+      },
+      "supported": true,
+      "tier": "quick",
+      "top_files": [
+        "lib/dry/configurable/config.rb",
+        "lib/dry/configurable/class_methods.rb",
+        "lib/dry/configurable/settings.rb",
+        "lib/dry/configurable/instance_methods.rb",
+        "lib/dry/configurable/dsl.rb",
+        "lib/dry/configurable/methods.rb",
+        "lib/dry/configurable/setting.rb",
+        "lib/dry/configurable/compiler.rb",
+        "lib/dry/configurable.rb",
+        "lib/dry/configurable/extension.rb"
+      ]
+    }
+  ],
+  "repositories": {
+    "attrs": {
+      "content_types": [
+        "code",
+        "markdown",
+        "rst"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 245,
+        "files_processed": 52,
+        "index_ms": 14895.27
+      },
+      "languages": [
+        "python"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/python-attrs/attrs.git",
+      "revision": "d544dd2dacb4cbd660891e323ad92751ba65b4e0"
+    },
+    "dry-configurable": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 30,
+        "files_processed": 16,
+        "index_ms": 4376.8
+      },
+      "languages": [
+        "ruby"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/dry-rb/dry-configurable.git",
+      "revision": "e5e025dfddb481485affe6bb7363d3cf37f153b5"
+    },
+    "fastroute": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 65,
+        "files_processed": 32,
+        "index_ms": 17375.97
+      },
+      "languages": [
+        "php"
+      ],
+      "license": "BSD-3-Clause",
+      "repository_url": "https://github.com/nikic/FastRoute.git",
+      "revision": "1c961398bef1ff6ecd8b273bef651d7afe90312b"
+    },
+    "hono": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 356,
+        "files_processed": 315,
+        "index_ms": 67467.09
+      },
+      "languages": [
+        "typescript",
+        "javascript"
+      ],
+      "license": "MIT",
+      "repository_url": "https://github.com/honojs/hono.git",
+      "revision": "b2ae3a2204a48ce15a26448fd746d39745eb1837"
+    },
+    "pflag": {
+      "content_types": [
+        "code",
+        "markdown"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 1576,
+        "files_processed": 79,
+        "index_ms": 104658.22
+      },
+      "languages": [
+        "go"
+      ],
+      "license": "BSD-3-Clause",
+      "repository_url": "https://github.com/spf13/pflag.git",
+      "revision": "5fdac2d16c16d60605cb8baa887e8c5c38ef623f"
+    },
+    "swift-argument-parser": {
+      "content_types": [
+        "code",
+        "markdown",
+        "docc"
+      ],
+      "index": {
+        "cached": false,
+        "chunks_created": 447,
+        "files_processed": 75,
+        "index_ms": 58707.93
+      },
+      "languages": [
+        "swift"
+      ],
+      "license": "Apache-2.0",
+      "repository_url": "https://github.com/apple/swift-argument-parser.git",
+      "revision": "e579882f95579e7d7eb8c8068a5925c65d361e91"
+    }
+  },
+  "summary": {
+    "candidate_pool": {
+      "current_page_content": {
+        "max_document_chars": 57250,
+        "mean_pool_candidates": 8.6,
+        "mean_pool_duplicate_file_rate": 0.272222,
+        "mean_pool_unique_files": 6.166667,
+        "mean_raw_candidates": 8.6
+      },
+      "expanded_coverage_first_content": {
+        "max_document_chars": 62576,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.183593,
+        "mean_pool_unique_files": 21.766667,
+        "mean_raw_candidates": 92.433333
+      },
+      "expanded_score_order_content": {
+        "max_document_chars": 62576,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.434704,
+        "mean_pool_unique_files": 14.233333,
+        "mean_raw_candidates": 92.433333
+      },
+      "two_stage_structured": {
+        "max_document_chars": 4096,
+        "mean_pool_candidates": 25.9,
+        "mean_pool_duplicate_file_rate": 0.183593,
+        "mean_pool_unique_files": 21.766667,
+        "mean_raw_candidates": 92.433333
+      }
+    },
+    "latency": {
+      "current_page_content": {
+        "mean_ms": 998.94,
+        "p50_ms": 681.79,
+        "p95_ms": 3406.24
+      },
+      "expanded_coverage_first_content": {
+        "mean_ms": 3469.5,
+        "p50_ms": 2318.39,
+        "p95_ms": 12177.25
+      },
+      "expanded_score_order_content": {
+        "mean_ms": 3053.91,
+        "p50_ms": 2038.88,
+        "p95_ms": 10176.39
+      },
+      "two_stage_structured": {
+        "mean_ms": 2818.08,
+        "p50_ms": 2044.18,
+        "p95_ms": 8093.41
+      }
+    },
+    "paired_macro_mrr": {
+      "expanded_coverage_first_content": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.14246,
+        "ci_upper": 0.056944,
+        "confidence": 0.95,
+        "delta": -0.030238,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.719762,
+        "treatment_engine": "expanded_coverage_first_content"
+      },
+      "expanded_score_order_content": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.047778,
+        "ci_upper": 0.145556,
+        "confidence": 0.95,
+        "delta": 0.04,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.79,
+        "treatment_engine": "expanded_score_order_content"
+      },
+      "two_stage_structured": {
+        "baseline": 0.75,
+        "baseline_engine": "current_page_content",
+        "bootstrap_unit": "repository",
+        "ci_lower": -0.058353,
+        "ci_upper": 0.157937,
+        "confidence": 0.95,
+        "delta": 0.05119,
+        "iterations": 10000,
+        "metric": "macro_mrr_at_10_delta",
+        "paired_queries": 30,
+        "repositories": 6,
+        "seed": 1729,
+        "treatment": 0.80119,
+        "treatment_engine": "two_stage_structured"
+      }
+    },
+    "per_repository": {
+      "attrs": {
+        "current_page_content": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        }
+      },
+      "dry-configurable": {
+        "current_page_content": {
+          "mrr_at_10": 0.716667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.683333,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 0.8
+        }
+      },
+      "fastroute": {
+        "current_page_content": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.828571,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        }
+      },
+      "hono": {
+        "current_page_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.85,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        }
+      },
+      "pflag": {
+        "current_page_content": {
+          "mrr_at_10": 0.65,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.595238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.828571,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        }
+      },
+      "swift-argument-parser": {
+        "current_page_content": {
+          "mrr_at_10": 0.766667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content": {
+          "mrr_at_10": 0.491667,
+          "queries_supported": 5,
+          "top_1": 0.2,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content": {
+          "mrr_at_10": 0.633333,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured": {
+          "mrr_at_10": 0.616667,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        }
+      }
+    },
+    "pooled": {
+      "current_page_content": {
+        "mrr_at_10": 0.75,
+        "queries_supported": 30,
+        "top_1": 0.6,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.966667
+      },
+      "expanded_coverage_first_content": {
+        "mrr_at_10": 0.719762,
+        "queries_supported": 30,
+        "top_1": 0.566667,
+        "top_10": 1.0,
+        "top_3": 0.866667,
+        "top_5": 0.9
+      },
+      "expanded_score_order_content": {
+        "mrr_at_10": 0.79,
+        "queries_supported": 30,
+        "top_1": 0.666667,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.933333
+      },
+      "two_stage_structured": {
+        "mrr_at_10": 0.80119,
+        "queries_supported": 30,
+        "top_1": 0.733333,
+        "top_10": 1.0,
+        "top_3": 0.8,
+        "top_5": 0.9
+      }
+    },
+    "predeclared_gates": {
+      "added_p95_at_most_300_ms": false,
+      "macro_mrr_non_negative": true,
+      "max_document_chars_enforced": true,
+      "passed": false,
+      "treatment_p95_at_most_500_ms": false
+    },
+    "primary_macro_per_repository": {
+      "current_page_content": {
+        "mrr_at_10": 0.75,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 0.866667,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.716667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.6,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 0.8,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.65,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.766667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.6,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.966667
+      },
+      "expanded_coverage_first_content": {
+        "mrr_at_10": 0.719762,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.706667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.625,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.595238,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.491667,
+            "queries_supported": 5,
+            "top_1": 0.2,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.566667,
+        "top_10": 1.0,
+        "top_3": 0.866667,
+        "top_5": 0.9
+      },
+      "expanded_score_order_content": {
+        "mrr_at_10": 0.79,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.706667,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "fastroute": {
+            "mrr_at_10": 0.6,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 0.8,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.9,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.633333,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.666667,
+        "top_10": 0.966667,
+        "top_3": 0.9,
+        "top_5": 0.933333
+      },
+      "two_stage_structured": {
+        "mrr_at_10": 0.80119,
+        "per_repository": {
+          "attrs": {
+            "mrr_at_10": 1.0,
+            "queries_supported": 5,
+            "top_1": 1.0,
+            "top_10": 1.0,
+            "top_3": 1.0,
+            "top_5": 1.0
+          },
+          "dry-configurable": {
+            "mrr_at_10": 0.683333,
+            "queries_supported": 5,
+            "top_1": 0.6,
+            "top_10": 1.0,
+            "top_3": 0.6,
+            "top_5": 0.8
+          },
+          "fastroute": {
+            "mrr_at_10": 0.828571,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "hono": {
+            "mrr_at_10": 0.85,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          },
+          "pflag": {
+            "mrr_at_10": 0.828571,
+            "queries_supported": 5,
+            "top_1": 0.8,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 0.8
+          },
+          "swift-argument-parser": {
+            "mrr_at_10": 0.616667,
+            "queries_supported": 5,
+            "top_1": 0.4,
+            "top_10": 1.0,
+            "top_3": 0.8,
+            "top_5": 1.0
+          }
+        },
+        "queries_supported": 30,
+        "repositories": 6,
+        "top_1": 0.733333,
+        "top_10": 1.0,
+        "top_3": 0.8,
+        "top_5": 0.9
+      }
+    },
+    "protected_segments": {
+      "content_type": {
+        "current_page_content/code": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 18,
+          "top_1": 0.388889,
+          "top_10": 0.944444,
+          "top_3": 0.888889,
+          "top_5": 0.944444
+        },
+        "current_page_content/document": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 6,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/mixed": {
+          "mrr_at_10": 0.875,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/code": {
+          "mrr_at_10": 0.605159,
+          "queries_supported": 18,
+          "top_1": 0.388889,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 0.833333
+        },
+        "expanded_coverage_first_content/document": {
+          "mrr_at_10": 0.916667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/mixed": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/code": {
+          "mrr_at_10": 0.722222,
+          "queries_supported": 18,
+          "top_1": 0.555556,
+          "top_10": 0.944444,
+          "top_3": 0.888889,
+          "top_5": 0.888889
+        },
+        "expanded_score_order_content/document": {
+          "mrr_at_10": 0.916667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/mixed": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        },
+        "two_stage_structured/code": {
+          "mrr_at_10": 0.738095,
+          "queries_supported": 18,
+          "top_1": 0.666667,
+          "top_10": 1.0,
+          "top_3": 0.722222,
+          "top_5": 0.833333
+        },
+        "two_stage_structured/document": {
+          "mrr_at_10": 0.916667,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/mixed": {
+          "mrr_at_10": 0.875,
+          "queries_supported": 6,
+          "top_1": 0.833333,
+          "top_10": 1.0,
+          "top_3": 0.833333,
+          "top_5": 1.0
+        }
+      },
+      "language": {
+        "current_page_content/go": {
+          "mrr_at_10": 0.65,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "current_page_content/php": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "current_page_content/python": {
+          "mrr_at_10": 0.866667,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/ruby": {
+          "mrr_at_10": 0.716667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "current_page_content/swift": {
+          "mrr_at_10": 0.766667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "current_page_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/go": {
+          "mrr_at_10": 0.595238,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/php": {
+          "mrr_at_10": 0.625,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/ruby": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_coverage_first_content/swift": {
+          "mrr_at_10": 0.491667,
+          "queries_supported": 5,
+          "top_1": 0.2,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_coverage_first_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/go": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/php": {
+          "mrr_at_10": 0.6,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 0.8,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/ruby": {
+          "mrr_at_10": 0.706667,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "expanded_score_order_content/swift": {
+          "mrr_at_10": 0.633333,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "expanded_score_order_content/typescript": {
+          "mrr_at_10": 0.9,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/go": {
+          "mrr_at_10": 0.828571,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured/php": {
+          "mrr_at_10": 0.828571,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 0.8
+        },
+        "two_stage_structured/python": {
+          "mrr_at_10": 1.0,
+          "queries_supported": 5,
+          "top_1": 1.0,
+          "top_10": 1.0,
+          "top_3": 1.0,
+          "top_5": 1.0
+        },
+        "two_stage_structured/ruby": {
+          "mrr_at_10": 0.683333,
+          "queries_supported": 5,
+          "top_1": 0.6,
+          "top_10": 1.0,
+          "top_3": 0.6,
+          "top_5": 0.8
+        },
+        "two_stage_structured/swift": {
+          "mrr_at_10": 0.616667,
+          "queries_supported": 5,
+          "top_1": 0.4,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        },
+        "two_stage_structured/typescript": {
+          "mrr_at_10": 0.85,
+          "queries_supported": 5,
+          "top_1": 0.8,
+          "top_10": 1.0,
+          "top_3": 0.8,
+          "top_5": 1.0
+        }
+      }
+    }
+  }
+}

--- a/docs/benchmark-two-stage-retrieval-2026-07-14.md
+++ b/docs/benchmark-two-stage-retrieval-2026-07-14.md
@@ -115,7 +115,11 @@ useful:
    latency budget, without coupling model selection to this retrieval PR.
 
 The sealed holdout remains unopened. A future replacement for PR-03 needs a new
-predeclared experiment and independent validation before merge.
+predeclared experiment and independent validation before merge. Follow-up work
+is recorded in
+[the latency-bounded cascade issue](https://github.com/danieliser/tessera/issues/17),
+[the model-policy issue](https://github.com/danieliser/tessera/issues/12), and
+[the relevance-aware diversity issue](https://github.com/danieliser/tessera/issues/18).
 
 ## Artifacts and reproduction
 

--- a/docs/benchmark-two-stage-retrieval-2026-07-14.md
+++ b/docs/benchmark-two-stage-retrieval-2026-07-14.md
@@ -1,0 +1,136 @@
+# Two-stage retrieval experiment — 2026-07-14
+
+PR-03 is not safe to merge. A real expanded rerank pool improved some file-level
+quality metrics and recovered the one current Top-10 miss, but neither the
+initial full-context treatment nor a principled fixed-total-context remediation
+met the predeclared latency gates. The remediation's macro MRR gain was small,
+uncertain, and uneven across repositories.
+
+## Frozen inputs
+
+| Item | Value |
+|---|---|
+| Initial revision | `c36c093883909945d0e5f2418e7664ffacfe8473` |
+| Remediation revision | `e8dbc0a414da6dd9857a693a746b644871a08818` |
+| Corpus manifest SHA-256 | `0e84423ee5f116554af104908b0ba845cee25bc69bfecc38cb813e3deab1c701` |
+| Repositories | attrs, Hono, FastRoute, pflag, swift-argument-parser, dry-configurable |
+| Languages | Python, TypeScript, PHP, Go, Swift, Ruby |
+| Content | code, document/Markdown, mixed |
+| Embedding model | `BAAI/bge-small-en-v1.5` |
+| Reranker | `Xenova/ms-marco-MiniLM-L-6-v2` |
+| Queries | 30 development queries; no holdout access |
+
+The experiment did not sweep pool sizes, context limits, queries, or models.
+The pool multiplier of three was inherited from the existing server's nominal
+pool. The raw over-fetch factor of five reused the existing unique-file
+over-fetch policy.
+
+## Final remediation result
+
+| Engine | Macro MRR@10 | Top-1 | Top-10 | p95 | Mean pool files | Duplicate-file rate |
+|---|---:|---:|---:|---:|---:|---:|
+| Current page/content | 0.750000 | 60.0% | 96.7% | 2,824.68 ms | 6.17 | 27.2% |
+| Expanded score-order/content | 0.790000 | 66.7% | 96.7% | 11,988.71 ms | 14.23 | 43.5% |
+| Expanded coverage-first/content | 0.719762 | 56.7% | 100% | 13,418.29 ms | 21.77 | 18.4% |
+| Two-stage structured/remediated | 0.758095 | 66.7% | 100% | 5,824.85 ms | 21.77 | 18.4% |
+
+The final treatment's macro MRR delta was `+0.008095`; its repository-paired
+95% bootstrap interval was `[-0.157381, +0.132778]`. This is non-negative at
+the point estimate but not persuasive evidence of a general quality gain.
+
+| Repository | Current MRR | Treatment MRR | Delta |
+|---|---:|---:|---:|
+| attrs | 0.866667 | 1.000000 | +0.133333 |
+| Hono | 0.900000 | 0.545238 | -0.354762 |
+| FastRoute | 0.600000 | 0.750000 | +0.150000 |
+| pflag | 0.650000 | 0.833333 | +0.183333 |
+| swift-argument-parser | 0.766667 | 0.740000 | -0.026667 |
+| dry-configurable | 0.716667 | 0.680000 | -0.036667 |
+
+Code MRR improved from 0.625000 to 0.688889 and document MRR remained 1.0,
+but the six mixed code/document queries fell from 0.875000 to 0.723810. With
+five cases per repository and six per content guardrail, these movements are
+diagnostic rather than stable estimates; Hono's regression is nevertheless too
+large to dismiss.
+
+## Initial result and remediation
+
+The initial structured treatment capped each of 30 candidates at 4,096
+characters. It increased macro MRR from 0.750000 to 0.801190 and Top-1 from
+60.0% to 73.3%, but p95 was 8,093.41 ms against 3,406.24 ms current. It failed
+the 500 ms absolute and +300 ms added-p95 gates.
+
+That result was rejected rather than used to loosen the gates. The remediation
+kept the incumbent visible page's total model-context budget fixed: one
+512-token window was approximated as 2,048 characters, and the total
+`visible_limit * 2,048` characters was divided across the actual pool. The
+default 10-visible/30-candidate path therefore received 682 characters per
+candidate. The model, pool, raw retrieval, queries, and gates were unchanged.
+
+A label-free warm synthetic check isolated the intended mechanism:
+
+| Generic reranker input | Median | Maximum over 5 measured runs |
+|---|---:|---:|
+| 10 × 4,096 characters | 1,544.71 ms | 1,765.00 ms |
+| 30 × 4,096 characters | 4,013.84 ms | 4,606.32 ms |
+| 30 × 1,365 characters | 574.93 ms | 590.54 ms |
+| 30 × 682 characters | 351.20 ms | 444.04 ms |
+| 30 × 341 characters | 148.98 ms | 173.65 ms |
+
+The exact remediation corpus run occurred while the host was heavily
+contended: another local model held roughly 31% of RAM, swap reached about
+30.7 GiB, and unrelated CPU-heavy processes were active. Its absolute latency
+is therefore a conservative observation, but the experiment still fails its
+declared wall-clock gate. No post-result context reduction is adopted to chase
+the public corpus.
+
+## Deterministic evidence
+
+The old server failed the promotion fixture because `hybrid_search` received
+only the visible `limit=2`; candidate three never reached the reranker. The new
+fixture requests the declared raw depth, limits the actual cross-encoder pool,
+and promotes candidate three to rank one. Separate invariants cover:
+
+- unchanged `limit` and ordering when reranking is disabled;
+- bounded pool and raw-fetch budgets, including visible limits above the cap;
+- coverage-first ordering across projects/files and safe unknown-path identity;
+- second-chunk backfill after each available file receives one candidate;
+- structured path, source, line, section/key, and indexed-symbol context;
+- malformed symbol metadata and dynamic total-context bounds;
+- trace attribution for requested pool, raw retrieval depth, selection policy,
+  and actual document cap.
+
+## Decision and follow-ups
+
+Do not merge the production change from this experiment. Three findings remain
+useful:
+
+1. The nominal server pool was indeed not real; the deterministic defect and
+   FastRoute recovery validate the candidate-eligibility hypothesis.
+2. Hard coverage-first selection is too blunt. It reduces duplicate crowding
+   but can lower MRR; file diversity should be relevance-aware or implemented
+   in the hierarchical file-to-chunk stage planned for PR-06.
+3. Cross-encoder throughput is the binding constraint. A separate model/cascade
+   experiment should compare supported rerankers under a fixed total token and
+   latency budget, without coupling model selection to this retrieval PR.
+
+The sealed holdout remains unopened. A future replacement for PR-03 needs a new
+predeclared experiment and independent validation before merge.
+
+## Artifacts and reproduction
+
+- Initial failed run:
+  [`benchmarks/development-two-stage-initial-2026-07-14.json`](/benchmarks/development-two-stage-initial-2026-07-14.json)
+- Context-conserving remediation:
+  [`benchmarks/development-two-stage-2026-07-14.json`](/benchmarks/development-two-stage-2026-07-14.json)
+
+```bash
+uv run pytest -q \
+  tests/unit/test_rerank.py \
+  tests/unit/test_search_trace.py \
+  tests/integration/test_server.py
+
+uv run python scripts/benchmark_two_stage.py \
+  --tier quick \
+  --output benchmarks/development-two-stage-2026-07-14.json
+```

--- a/docs/plans/retrieval-quality-master-plan/PLAN.md
+++ b/docs/plans/retrieval-quality-master-plan/PLAN.md
@@ -176,14 +176,24 @@ tests, lint, and strict docs. See
 
 **Goal:** Decouple the candidate budget from the user-visible result limit.
 
-- [ ] Compute a candidate budget before per-project retrieval when a reranker is active.
-- [ ] Retrieve enough channel candidates to populate that budget instead of requesting only the final `limit`.
-- [ ] Prevent duplicate chunks from one file from starving the reranker while preserving an explicit way to return multiple useful chunks from a selected file.
-- [ ] Pass structured candidate text to the reranker, including stable path/symbol context where available.
-- [ ] Add red/green tests proving a requested result outside the first output page can be promoted by the reranker.
-- [ ] Predeclare the candidate budget from latency/memory constraints; do not choose it on the legacy benchmark.
+- [x] Compute a candidate budget before per-project retrieval when a reranker is active.
+- [x] Retrieve enough channel candidates to populate that budget instead of requesting only the final `limit`.
+- [x] Prevent duplicate chunks from one file from starving the reranker while preserving an explicit way to return multiple useful chunks from a selected file.
+- [x] Pass structured candidate text to the reranker, including stable path/symbol context where available.
+- [x] Add red/green tests proving a requested result outside the first output page can be promoted by the reranker.
+- [x] Predeclare the candidate budget from latency/memory constraints; do not choose it on the legacy benchmark.
 
 **Gate:** The reranker receives the declared unique candidate pool, invariant tests fail before/pass after, development-corpus quality is non-negative, and p95 remains within the declared budget.
+
+**Experiment rejected:** Both the initial and context-conserving treatments
+failed the predeclared latency gates. The remediation retained only a small,
+uncertain macro MRR gain (`+0.008095`) and had a large Hono regression; hard
+coverage-first selection independently reduced macro MRR. PR-03 remains an
+unmerged draft. See
+[the experiment declaration](PR-03.md) and
+[full result](../../benchmark-two-stage-retrieval-2026-07-14.md). Cross-encoder
+throughput/model selection and relevance-aware diversity must proceed as
+separate experiments; PR-04 does not depend on this rejected production path.
 
 ### PR-04 — Searchable file/path candidate channel
 

--- a/docs/plans/retrieval-quality-master-plan/PLAN.md
+++ b/docs/plans/retrieval-quality-master-plan/PLAN.md
@@ -188,12 +188,15 @@ tests, lint, and strict docs. See
 **Experiment rejected:** Both the initial and context-conserving treatments
 failed the predeclared latency gates. The remediation retained only a small,
 uncertain macro MRR gain (`+0.008095`) and had a large Hono regression; hard
-coverage-first selection independently reduced macro MRR. PR-03 remains an
-unmerged draft. See
+coverage-first selection independently reduced macro MRR. PR-03 remains
+[unmerged draft PR #16](https://github.com/danieliser/tessera/pull/16). See
 [the experiment declaration](PR-03.md) and
 [full result](../../benchmark-two-stage-retrieval-2026-07-14.md). Cross-encoder
-throughput/model selection and relevance-aware diversity must proceed as
-separate experiments; PR-04 does not depend on this rejected production path.
+throughput/model selection and relevance-aware diversity must proceed through
+[issue #17](https://github.com/danieliser/tessera/issues/17),
+[issue #12](https://github.com/danieliser/tessera/issues/12), and
+[issue #18](https://github.com/danieliser/tessera/issues/18); PR-04 does not
+depend on this rejected production path.
 
 ### PR-04 — Searchable file/path candidate channel
 

--- a/docs/plans/retrieval-quality-master-plan/PR-03.md
+++ b/docs/plans/retrieval-quality-master-plan/PR-03.md
@@ -153,5 +153,21 @@ uv run python scripts/benchmark_two_stage.py \
   --output benchmarks/development-two-stage-2026-07-14.json
 ```
 
-The remediation result and exact revision will be appended only after its
-treatment run.
+## Remediation result — rejected
+
+At `e8dbc0a414da6dd9857a693a746b644871a08818`, the context-conserving
+treatment retained only a `+0.008095` macro MRR point estimate over current
+behavior (`0.750000 → 0.758095`) with a wide repository-paired 95% interval of
+`[-0.157381, +0.132778]`. Top-1 improved from 60.0% to 66.7% and Top-10 from
+96.7% to 100%, but Hono MRR regressed by 0.354762.
+
+Treatment p95 was 5,824.85 ms against 2,824.68 ms current under a heavily
+contended host. It failed both unchanged latency gates. Coverage-first content
+alone also reduced macro MRR by 0.030238, demonstrating that diversity cannot
+be treated as a relevance-independent ranking rule.
+
+**Decision:** do not merge PR-03's production change. Preserve the deterministic
+defect fixture, benchmark harness, and artifacts in the draft experiment, then
+move cross-encoder throughput/model work and relevance-aware diversity into
+separate follow-ups. See
+[the full PR-03 report](../../benchmark-two-stage-retrieval-2026-07-14.md).

--- a/docs/plans/retrieval-quality-master-plan/PR-03.md
+++ b/docs/plans/retrieval-quality-master-plan/PR-03.md
@@ -1,0 +1,115 @@
+# PR-03 — Real two-stage retrieval and rerank pool
+
+**Declared before treatment measurement:** 2026-07-14
+
+**Evidence class:** deterministic correctness, paired retrieval quality, and
+performance/operations
+
+## Hypothesis
+
+The server currently allocates a nominal rerank pool of `3 * limit` only after
+asking each project-local search for `limit` results. In a single project, the
+reranker therefore never sees a candidate beyond the visible page; in a
+federated search, extra candidates can only come from project fan-out. A real
+two-stage path should retrieve the already-intended larger pool before global
+selection, give every available file one candidate before adding second chunks,
+and describe each candidate with stable provenance. That should allow the
+active cross-encoder to promote relevant candidates without changing the
+no-reranker path.
+
+This PR changes candidate eligibility, not source-channel scores. It does not
+add query-specific rules, a new retrieval channel, a model sweep, or a constant
+selected from corpus results.
+
+## Predeclared production policy
+
+1. With a reranker active, the cross-encoder candidate budget is three times
+   the requested visible limit. Three preserves the server's pre-existing
+   stated rerank-pool policy; it is moved before retrieval rather than selected
+   from benchmark output.
+2. Extra cross-encoder candidates are capped at a total pool of 50, while the pool is never
+   smaller than the requested visible limit. Formally, for positive `limit`,
+   `max(limit, min(3 * limit, 50))`. The cap bounds normal cross-encoder work;
+   an explicitly requested visible limit above 50 remains honored but gets no
+   additional expansion.
+3. To make file coverage possible rather than merely reorder an already-full
+   duplicate pool, each project may retrieve five times the cross-encoder
+   candidate budget, capped at 250 and never below that candidate budget. Five
+   reuses `hybrid_search`'s existing generic unique-file over-fetch policy; 250
+   bounds metadata and fusion work. Only the smaller pool reaches the
+   cross-encoder.
+4. Global pool selection is coverage-first: take the highest-ranked candidate
+   for each `(project, file)` before filling remaining slots in original score
+   order. This has no tuned per-file quota and still permits multiple useful
+   chunks whenever pool capacity remains after file coverage.
+5. Each reranker document has a stable labeled header for project, path,
+   source type, line range, and indexed symbols when available. The complete
+   document is capped at 4,096 Unicode characters and at most eight symbol
+   records, bounding the normal 50-candidate input to about 200 KiB of text.
+   Missing or malformed symbol metadata falls back to the other fields without
+   failing search.
+6. When no reranker is active, project-local retrieval remains exactly
+   `limit`, no structured reranker text is built, and result ordering is
+   unchanged.
+
+These limits are operational choices based on bounded CPU cross-encoder input
+and memory, declared before running the development treatment. They are not
+derived from a visible success case.
+
+## Predeclared gates
+
+1. A deterministic server fixture with `limit=2` fails under the old path and
+   passes when an active reranker can promote candidate three or later. The
+   fixture also proves that each project receives the declared raw retrieval
+   budget and that only the smaller declared pool reaches the reranker.
+2. Deterministic pool fixtures prove coverage-first selection, stable ordering,
+   cross-project file identity, unknown-path safety, and the ability to include
+   multiple chunks once each known file has one candidate.
+3. Structured-document fixtures prove stable path/symbol context, the 4,096
+   character bound, and graceful malformed/missing metadata handling.
+4. The no-reranker server path requests only `limit` candidates and retains its
+   previous output order.
+5. On the six-repository development corpus, the treatment's primary
+   macro-per-repository MRR@10 is no lower than the current truncated-pool
+   baseline using the same frozen queries, indexes, embedder, and default local
+   reranker. Recall@10 and success@10 are secondary guardrails. Repository,
+   language, and content-type segments are reported; because some have only
+   five cases, segment movement is diagnostic rather than a tuning signal.
+6. Warm end-to-end treatment p95 is at most 500 ms/query and no more than
+   300 ms above the paired baseline p95 on this CPU. The serialized input bound
+   is enforced independently of observed latency.
+7. Relevant unit/integration suites, lint, and strict documentation pass. No
+   sealed holdout data is opened.
+
+## Paired comparison
+
+The benchmark will run each frozen development query through four declared
+stages with the same BGE-small embedding and default
+`Xenova/ms-marco-MiniLM-L-6-v2` cross-encoder:
+
+- **current:** retrieve only `limit`, content-only reranker input;
+- **expanded:** retrieve the declared raw over-fetch budget, retain the first
+  cross-encoder-budget candidates in score order, and use content-only input;
+- **diverse:** select the cross-encoder-budget pool coverage-first from that
+  same raw set;
+- **treatment:** add the bounded structured reranker document used by the
+  server.
+
+The first three are mechanism diagnostics, not independent configurations from
+which production constants may be chosen. The only merge decision is the
+predeclared full treatment versus current behavior.
+
+## Planned reproduction
+
+```bash
+uv run pytest -q \
+  tests/unit/test_rerank.py \
+  tests/unit/test_search_trace.py \
+  tests/integration/test_server.py
+
+uv run python scripts/benchmark_two_stage.py \
+  --tier quick \
+  --output benchmarks/development-two-stage-2026-07-14.json
+```
+
+The result and exact revision will be appended only after the treatment run.

--- a/docs/plans/retrieval-quality-master-plan/PR-03.md
+++ b/docs/plans/retrieval-quality-master-plan/PR-03.md
@@ -169,5 +169,8 @@ be treated as a relevance-independent ranking rule.
 **Decision:** do not merge PR-03's production change. Preserve the deterministic
 defect fixture, benchmark harness, and artifacts in the draft experiment, then
 move cross-encoder throughput/model work and relevance-aware diversity into
-separate follow-ups. See
+separate follow-ups in
+[issue #17](https://github.com/danieliser/tessera/issues/17),
+[issue #12](https://github.com/danieliser/tessera/issues/12), and
+[issue #18](https://github.com/danieliser/tessera/issues/18). See
 [the full PR-03 report](../../benchmark-two-stage-retrieval-2026-07-14.md).

--- a/docs/plans/retrieval-quality-master-plan/PR-03.md
+++ b/docs/plans/retrieval-quality-master-plan/PR-03.md
@@ -27,8 +27,8 @@ selected from corpus results.
    the requested visible limit. Three preserves the server's pre-existing
    stated rerank-pool policy; it is moved before retrieval rather than selected
    from benchmark output.
-2. Extra cross-encoder candidates are capped at a total pool of 50, while the pool is never
-   smaller than the requested visible limit. Formally, for positive `limit`,
+2. Extra cross-encoder candidates are capped at a total pool of 50, while the
+   pool is never smaller than the requested visible limit. Formally, for positive `limit`,
    `max(limit, min(3 * limit, 50))`. The cap bounds normal cross-encoder work;
    an explicitly requested visible limit above 50 remains honored but gets no
    additional expansion.
@@ -43,18 +43,17 @@ selected from corpus results.
    order. This has no tuned per-file quota and still permits multiple useful
    chunks whenever pool capacity remains after file coverage.
 5. Each reranker document has a stable labeled header for project, path,
-   source type, line range, and indexed symbols when available. The complete
-   document is capped at 4,096 Unicode characters and at most eight symbol
-   records, bounding the normal 50-candidate input to about 200 KiB of text.
+   source type, line range, and at most eight indexed symbols when available.
    Missing or malformed symbol metadata falls back to the other fields without
-   failing search.
+   failing search. The initial experiment capped every document at 4,096
+   Unicode characters.
 6. When no reranker is active, project-local retrieval remains exactly
    `limit`, no structured reranker text is built, and result ordering is
    unchanged.
 
-These limits are operational choices based on bounded CPU cross-encoder input
-and memory, declared before running the development treatment. They are not
-derived from a visible success case.
+The pool and initial document limits were operational choices based on bounded
+CPU cross-encoder input and memory, declared before running the development
+treatment. They were not derived from a visible success case.
 
 ## Predeclared gates
 
@@ -65,7 +64,7 @@ derived from a visible success case.
 2. Deterministic pool fixtures prove coverage-first selection, stable ordering,
    cross-project file identity, unknown-path safety, and the ability to include
    multiple chunks once each known file has one candidate.
-3. Structured-document fixtures prove stable path/symbol context, the 4,096
+3. Structured-document fixtures prove stable path/symbol context, the declared
    character bound, and graceful malformed/missing metadata handling.
 4. The no-reranker server path requests only `limit` candidates and retains its
    previous output order.
@@ -99,6 +98,48 @@ The first three are mechanism diagnostics, not independent configurations from
 which production constants may be chosen. The only merge decision is the
 predeclared full treatment versus current behavior.
 
+## Initial result — rejected on latency
+
+The first treatment at `c36c093883909945d0e5f2418e7664ffacfe8473`
+passed the quality and document-bound checks but failed both latency gates. On
+30 queries across all six development repositories:
+
+- macro MRR@10 increased from 0.750000 to 0.801190 (`+0.051190`), with a
+  repository-paired 95% interval of `[-0.058353, +0.157937]`;
+- Top-1 increased from 60.0% to 73.3%, and Top-10 from 96.7% to 100%;
+- the treatment reduced mean duplicate-file rate in the rerank pool from
+  43.5% in score order to 18.4%;
+- treatment p95 was 8,093.41 ms versus 3,406.24 ms for current behavior,
+  failing both the 500 ms absolute and +300 ms added-p95 gates.
+
+The failed result is preserved in
+`benchmarks/development-two-stage-initial-2026-07-14.json`. It is not merge
+evidence, and the latency gates are not relaxed after observing it.
+
+## Remediation experiment declaration
+
+The failure scales with total cross-encoder tokens: the expanded pool tripled
+the number of full context windows. Before rerunning the development treatment,
+the input policy is changed to conserve the incumbent visible page's total
+context instead of multiplying it:
+
+1. One model context is represented by 2,048 characters (the default
+   reranker's 512-token window at the standard four-characters-per-token
+   planning estimate).
+2. Total input is bounded by `visible_limit * 2,048` characters.
+3. The per-document limit is
+   `min(2,048, floor(total_input / actual_pool_size))`. At the default
+   10-visible/30-candidate path this is 682 characters per candidate.
+4. Candidate counts, raw over-fetch, coverage-first selection, model, queries,
+   and every original quality/latency gate remain unchanged.
+
+This is a general compute-budget correction, not a query-specific quality
+rule. A label-free synthetic warm check supports the mechanism: 30 generic
+4,096-character documents took about 4.0 seconds median, while 30 generic
+682-character documents took about 351 ms. Because the initial public quality
+outcomes are now known, the rerun is an iterative development result rather
+than independent confirmation; the sealed holdout remains unopened.
+
 ## Planned reproduction
 
 ```bash
@@ -112,4 +153,5 @@ uv run python scripts/benchmark_two_stage.py \
   --output benchmarks/development-two-stage-2026-07-14.json
 ```
 
-The result and exact revision will be appended only after the treatment run.
+The remediation result and exact revision will be appended only after its
+treatment run.

--- a/scripts/benchmark_two_stage.py
+++ b/scripts/benchmark_two_stage.py
@@ -66,6 +66,7 @@ from tessera.rerank import (  # noqa: E402
     RERANK_POOL_MULTIPLIER,
     build_rerank_documents,
     rerank_candidate_budget,
+    rerank_document_budget,
     rerank_retrieval_budget,
     select_rerank_candidates,
 )
@@ -120,8 +121,14 @@ def _run_case(
         pool = select_rerank_candidates(raw, candidate_budget)
 
     if engine == TREATMENT_ENGINE:
-        documents = build_rerank_documents(pool, {None: database})
+        document_char_budget = rerank_document_budget(TOP_K, len(pool))
+        documents = build_rerank_documents(
+            pool,
+            {None: database},
+            max_chars=document_char_budget,
+        )
     else:
+        document_char_budget = None
         documents = [str(candidate.get("content") or candidate.get("snippet") or "") for candidate in pool]
 
     reranked = reranker.rerank(case["query"], documents, top_k=TOP_K)
@@ -141,6 +148,7 @@ def _run_case(
         "raw_candidates": _candidate_metrics(raw),
         "rerank_pool": _candidate_metrics(pool),
         "max_document_chars": max((len(document) for document in documents), default=0),
+        "document_char_budget": document_char_budget,
     }
 
 
@@ -275,7 +283,7 @@ def main() -> int:
             "treatment_p95_at_most_500_ms": treatment_p95 <= 500.0,
             "added_p95_at_most_300_ms": treatment_p95 - baseline_p95 <= 300.0,
             "max_document_chars_enforced": all(
-                row["max_document_chars"] <= MAX_RERANK_DOCUMENT_CHARS
+                row["max_document_chars"] <= row["document_char_budget"]
                 for row in rows
                 if row["engine"] == TREATMENT_ENGINE
             ),
@@ -301,6 +309,7 @@ def main() -> int:
                 "raw_fetch_multiplier": RERANK_FETCH_MULTIPLIER,
                 "max_raw_fetch_size": MAX_RERANK_FETCH_SIZE,
                 "max_document_chars": MAX_RERANK_DOCUMENT_CHARS,
+                "document_budget_policy": "visible_limit_context_conserving",
             },
         )
         output = {

--- a/scripts/benchmark_two_stage.py
+++ b/scripts/benchmark_two_stage.py
@@ -1,0 +1,345 @@
+"""Run the predeclared PR-03 two-stage retrieval comparison.
+
+This is a paired development-corpus experiment. It compares current
+single-page reranking with the predeclared expanded, coverage-first, and
+structured-input stages without selecting among pool sizes or reranker models.
+
+Example:
+    uv run python scripts/benchmark_two_stage.py \
+      --tier quick \
+      --output benchmarks/development-two-stage-2026-07-14.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from benchmark_development import (  # noqa: E402
+    BASELINE_MODEL,
+    BASELINE_SEED,
+    DEFAULT_INDEX_ROOT,
+    TOP_K,
+    _dedupe_paths,
+    _git_revision,
+    _index_repository,
+    _latency_metrics,
+    _source_filter,
+    _tracked_worktree_changes,
+    rank_expected,
+)
+from benchmark_governance import (  # noqa: E402
+    DEFAULT_CHECKOUT_ROOT,
+    DEFAULT_MANIFEST,
+    build_run_metadata,
+    checkout_repository,
+    load_manifest,
+    load_queries,
+    macro_per_repository,
+    manifest_digest,
+    paired_bootstrap_interval,
+    protected_segment_metrics,
+    repositories_for_split,
+    retrieval_metrics,
+    validate_labels_against_checkout,
+)
+
+from tessera.db import ProjectDB  # noqa: E402
+from tessera.embeddings import FastembedClient, FastembedReranker  # noqa: E402
+from tessera.rerank import (  # noqa: E402
+    MAX_RERANK_DOCUMENT_CHARS,
+    MAX_RERANK_FETCH_SIZE,
+    MAX_RERANK_POOL_SIZE,
+    RERANK_FETCH_MULTIPLIER,
+    RERANK_POOL_MULTIPLIER,
+    build_rerank_documents,
+    rerank_candidate_budget,
+    rerank_retrieval_budget,
+    select_rerank_candidates,
+)
+from tessera.search import hybrid_search  # noqa: E402
+
+CURRENT_ENGINE = "current_page_content"
+EXPANDED_ENGINE = "expanded_score_order_content"
+DIVERSE_ENGINE = "expanded_coverage_first_content"
+TREATMENT_ENGINE = "two_stage_structured"
+ENGINES = [CURRENT_ENGINE, EXPANDED_ENGINE, DIVERSE_ENGINE, TREATMENT_ENGINE]
+DEFAULT_RERANKER = "Xenova/ms-marco-MiniLM-L-6-v2"
+
+
+def _candidate_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    known_paths = [str(result.get("file_path", "")) for result in results if result.get("file_path")]
+    unique_files = len(set(known_paths))
+    duplicates = len(known_paths) - unique_files
+    return {
+        "candidates": len(results),
+        "known_files": len(known_paths),
+        "unique_files": unique_files,
+        "duplicate_file_rate": round(duplicates / len(known_paths), 6) if known_paths else 0.0,
+    }
+
+
+def _run_case(
+    case: dict[str, Any],
+    database: ProjectDB,
+    embedder: FastembedClient,
+    reranker: FastembedReranker,
+    engine: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    embedding = np.asarray(embedder.embed_query(case["query"]), dtype=np.float32)
+    candidate_budget = rerank_candidate_budget(TOP_K, reranker_active=True)
+    retrieval_budget = rerank_retrieval_budget(candidate_budget, reranker_active=True)
+    requested = TOP_K if engine == CURRENT_ENGINE else retrieval_budget
+    raw = hybrid_search(
+        case["query"],
+        embedding,
+        database,
+        graph=None,
+        limit=requested,
+        source_type=_source_filter(case["category"]),
+    )
+
+    if engine == CURRENT_ENGINE:
+        pool = raw[:TOP_K]
+    elif engine == EXPANDED_ENGINE:
+        pool = raw[:candidate_budget]
+    else:
+        pool = select_rerank_candidates(raw, candidate_budget)
+
+    if engine == TREATMENT_ENGINE:
+        documents = build_rerank_documents(pool, {None: database})
+    else:
+        documents = [str(candidate.get("content") or candidate.get("snippet") or "") for candidate in pool]
+
+    reranked = reranker.rerank(case["query"], documents, top_k=TOP_K)
+    hits = [pool[index] for index, _score in reranked if 0 <= index < len(pool)]
+    paths = _dedupe_paths(hits)[:TOP_K]
+    rank = rank_expected(paths, case["expected_files"])
+    return {
+        **case,
+        "engine": engine,
+        "supported": True,
+        "rank": rank,
+        "reciprocal_rank": round(1.0 / rank, 6) if rank else 0.0,
+        "top_files": paths,
+        "latency_ms": round((time.perf_counter() - started) * 1000, 2),
+        "requested_retrieval_budget": requested,
+        "candidate_budget": len(pool),
+        "raw_candidates": _candidate_metrics(raw),
+        "rerank_pool": _candidate_metrics(pool),
+        "max_document_chars": max((len(document) for document in documents), default=0),
+    }
+
+
+def _candidate_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for engine in ENGINES:
+        selected = [row for row in rows if row["engine"] == engine]
+        result[engine] = {
+            "mean_raw_candidates": round(fmean(row["raw_candidates"]["candidates"] for row in selected), 6),
+            "mean_pool_candidates": round(fmean(row["rerank_pool"]["candidates"] for row in selected), 6),
+            "mean_pool_unique_files": round(fmean(row["rerank_pool"]["unique_files"] for row in selected), 6),
+            "mean_pool_duplicate_file_rate": round(
+                fmean(row["rerank_pool"]["duplicate_file_rate"] for row in selected),
+                6,
+            ),
+            "max_document_chars": max(row["max_document_chars"] for row in selected),
+        }
+    return result
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--repository", action="append", help="Development repository id; repeat as needed")
+    parser.add_argument("--tier", choices=["quick", "standard", "full"], default="quick")
+    parser.add_argument("--checkout-root", type=Path, default=DEFAULT_CHECKOUT_ROOT)
+    parser.add_argument("--index-root", type=Path, default=DEFAULT_INDEX_ROOT)
+    parser.add_argument("--reindex", action="store_true")
+    parser.add_argument("--reranker", default=DEFAULT_RERANKER)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    manifest = load_manifest(args.manifest)
+    available = {repository["id"]: repository for repository in repositories_for_split(manifest, "development")}
+    selected_ids = args.repository or list(available)
+    unknown = sorted(set(selected_ids) - available.keys())
+    if unknown:
+        raise SystemExit(f"Unknown development repositories: {', '.join(unknown)}")
+    if _tracked_worktree_changes(REPO_ROOT):
+        raise SystemExit(
+            "Two-stage benchmarks require a clean tracked Tessera worktree so the revision identifies the code exactly"
+        )
+
+    tessera_revision = _git_revision(REPO_ROOT)
+    corpus_digest = manifest_digest(args.manifest)
+    embedder = FastembedClient(model_name=BASELINE_MODEL)
+    reranker = FastembedReranker(model_name=args.reranker)
+    _ = embedder.embed_query("two-stage benchmark warmup")
+    _ = reranker.rerank("two-stage benchmark warmup", ["warmup document"], top_k=1)
+
+    revisions: dict[str, str] = {}
+    repository_metadata: dict[str, Any] = {}
+    databases: dict[str, ProjectDB] = {}
+    cases: list[dict[str, Any]] = []
+    try:
+        for repository_id in selected_ids:
+            repository = available[repository_id]
+            checkout = checkout_repository(repository, args.checkout_root)
+            repository_cases = load_queries(manifest, repository_id, args.tier)
+            validate_labels_against_checkout(repository, repository_cases, checkout)
+            revision = _git_revision(checkout)
+            revisions[repository_id] = revision
+            database, index_metadata = _index_repository(
+                repository,
+                checkout,
+                embedder,
+                args.index_root,
+                tessera_revision,
+                corpus_digest,
+                reindex=args.reindex,
+            )
+            databases[repository_id] = database
+            repository_metadata[repository_id] = {
+                "repository_url": repository["repository_url"],
+                "revision": revision,
+                "license": repository["license"],
+                "languages": repository["languages"],
+                "content_types": repository["content_types"],
+                "index": index_metadata,
+            }
+            cases.extend(repository_cases)
+
+        rows: list[dict[str, Any]] = []
+        total = len(cases) * len(ENGINES)
+        completed = 0
+        for case_index, case in enumerate(cases):
+            offset = case_index % len(ENGINES)
+            run_order = ENGINES[offset:] + ENGINES[:offset]
+            by_engine: dict[str, dict[str, Any]] = {}
+            for engine in run_order:
+                result = _run_case(
+                    case,
+                    databases[case["repository"]],
+                    embedder,
+                    reranker,
+                    engine,
+                )
+                by_engine[engine] = result
+                completed += 1
+                rank = result["rank"] if result["rank"] is not None else "MISS"
+                print(f"[{completed}/{total}] {case['repository']} / {case['case_id']} / {engine}: {rank}")
+            rows.extend(by_engine[engine] for engine in ENGINES)
+
+        per_repository: dict[str, dict[str, Any]] = {}
+        for repository_id in selected_ids:
+            per_repository[repository_id] = {
+                engine: retrieval_metrics(
+                    [row for row in rows if row["repository"] == repository_id and row["engine"] == engine]
+                )
+                for engine in ENGINES
+            }
+        latency = {engine: _latency_metrics([row for row in rows if row["engine"] == engine]) for engine in ENGINES}
+        macro = macro_per_repository(rows)
+        paired = {
+            engine: paired_bootstrap_interval(
+                rows,
+                CURRENT_ENGINE,
+                engine,
+                seed=BASELINE_SEED,
+            )
+            for engine in ENGINES[1:]
+        }
+        baseline_mrr = macro[CURRENT_ENGINE]["mrr_at_10"]
+        treatment_mrr = macro[TREATMENT_ENGINE]["mrr_at_10"]
+        treatment_p95 = latency[TREATMENT_ENGINE]["p95_ms"]
+        baseline_p95 = latency[CURRENT_ENGINE]["p95_ms"]
+        gates = {
+            "macro_mrr_non_negative": treatment_mrr >= baseline_mrr,
+            "treatment_p95_at_most_500_ms": treatment_p95 <= 500.0,
+            "added_p95_at_most_300_ms": treatment_p95 - baseline_p95 <= 300.0,
+            "max_document_chars_enforced": all(
+                row["max_document_chars"] <= MAX_RERANK_DOCUMENT_CHARS
+                for row in rows
+                if row["engine"] == TREATMENT_ENGINE
+            ),
+        }
+        gates["passed"] = all(gates.values())
+
+        metadata = build_run_metadata(
+            args.manifest,
+            "development",
+            revisions,
+            command=sys.argv,
+            seed=BASELINE_SEED,
+            extra={
+                "tier": args.tier,
+                "query_cases": len(cases),
+                "top_k": TOP_K,
+                "tessera_revision": tessera_revision,
+                "embedding_model": BASELINE_MODEL,
+                "reranking_model": args.reranker,
+                "engine_order_rotated": True,
+                "pool_multiplier": RERANK_POOL_MULTIPLIER,
+                "max_pool_size": MAX_RERANK_POOL_SIZE,
+                "raw_fetch_multiplier": RERANK_FETCH_MULTIPLIER,
+                "max_raw_fetch_size": MAX_RERANK_FETCH_SIZE,
+                "max_document_chars": MAX_RERANK_DOCUMENT_CHARS,
+            },
+        )
+        output = {
+            "metadata": metadata,
+            "repositories": repository_metadata,
+            "summary": {
+                "primary_macro_per_repository": macro,
+                "pooled": {
+                    engine: retrieval_metrics([row for row in rows if row["engine"] == engine]) for engine in ENGINES
+                },
+                "per_repository": per_repository,
+                "protected_segments": protected_segment_metrics(rows),
+                "latency": latency,
+                "candidate_pool": _candidate_summary(rows),
+                "paired_macro_mrr": paired,
+                "predeclared_gates": gates,
+            },
+            "queries": rows,
+            "limitations": [
+                "This is a public development treatment, not a sealed holdout result.",
+                "File-level labels do not score snippet usefulness, answer synthesis, or agent task completion.",
+                "The four stages diagnose one predeclared mechanism; they are not a model or pool-size sweep.",
+                "Segment samples are small and are reported as guardrails rather than tuning targets.",
+            ],
+        }
+        rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered)
+    finally:
+        for database in databases.values():
+            database.close()
+        reranker.close()
+        embedder.close()
+        ProjectDB.base_dir = None
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tessera/rerank.py
+++ b/src/tessera/rerank.py
@@ -1,0 +1,201 @@
+"""Bounded candidate preparation for two-stage retrieval and reranking."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+RERANK_POOL_MULTIPLIER = 3
+MAX_RERANK_POOL_SIZE = 50
+RERANK_FETCH_MULTIPLIER = 5
+MAX_RERANK_FETCH_SIZE = 250
+MAX_RERANK_DOCUMENT_CHARS = 4096
+MAX_RERANK_SYMBOLS = 8
+RERANK_POOL_SELECTION = "file_coverage_first"
+
+
+def rerank_candidate_budget(limit: int, *, reranker_active: bool) -> int:
+    """Return the project-local retrieval budget for a visible result limit.
+
+    The multiplier preserves the server's pre-existing nominal ``3 * limit``
+    rerank pool. The cap bounds extra cross-encoder work but never lowers an
+    explicitly requested visible limit.
+    """
+    if limit <= 0 or not reranker_active:
+        return limit
+    return max(limit, min(limit * RERANK_POOL_MULTIPLIER, MAX_RERANK_POOL_SIZE))
+
+
+def rerank_retrieval_budget(candidate_budget: int, *, reranker_active: bool) -> int:
+    """Return a bounded raw fetch depth from which to build a diverse pool.
+
+    Five matches the existing over-fetch policy used by ``hybrid_search`` when
+    it must find unique files. Here the raw candidates remain available for the
+    explicit coverage-first selector, so second chunks can backfill the pool.
+    """
+    if candidate_budget <= 0 or not reranker_active:
+        return candidate_budget
+    return max(
+        candidate_budget,
+        min(candidate_budget * RERANK_FETCH_MULTIPLIER, MAX_RERANK_FETCH_SIZE),
+    )
+
+
+def _project_key(result: dict[str, Any]) -> tuple[str, Any]:
+    if result.get("project_id") is not None:
+        return ("id", result["project_id"])
+    return ("name", result.get("project_name", ""))
+
+
+def _file_key(result: dict[str, Any], position: int) -> tuple[Any, ...]:
+    project = _project_key(result)
+    if result.get("file_id") is not None:
+        return (*project, "file_id", result["file_id"])
+    path = str(result.get("file_path", "")).replace("\\", "/")
+    if path:
+        return (*project, "path", path)
+    if result.get("id") is not None:
+        return (*project, "chunk", result["id"])
+    return (*project, "position", position)
+
+
+def select_rerank_candidates(
+    results: list[dict[str, Any]],
+    pool_size: int,
+) -> list[dict[str, Any]]:
+    """Select a stable coverage-first pool without hiding useful second chunks.
+
+    The input is already in retrieval-score order. The first pass takes the
+    best candidate for every project-local file. If capacity remains, a second
+    pass fills it in the original order, which permits multiple chunks from a
+    file without letting them starve all other files.
+    """
+    if pool_size <= 0:
+        return []
+
+    selected_positions: list[int] = []
+    selected_set: set[int] = set()
+    seen_files: set[tuple[Any, ...]] = set()
+    for position, result in enumerate(results):
+        key = _file_key(result, position)
+        if key in seen_files:
+            continue
+        seen_files.add(key)
+        selected_positions.append(position)
+        selected_set.add(position)
+        if len(selected_positions) == pool_size:
+            return [results[index] for index in selected_positions]
+
+    for position in range(len(results)):
+        if position in selected_set:
+            continue
+        selected_positions.append(position)
+        if len(selected_positions) == pool_size:
+            break
+
+    return [results[index] for index in selected_positions]
+
+
+def _parse_symbol_ids(value: Any) -> list[int]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
+    if not isinstance(value, (list, tuple)):
+        return []
+
+    symbol_ids: list[int] = []
+    seen: set[int] = set()
+    for raw_id in value:
+        try:
+            symbol_id = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if symbol_id in seen:
+            continue
+        seen.add(symbol_id)
+        symbol_ids.append(symbol_id)
+        if len(symbol_ids) == MAX_RERANK_SYMBOLS:
+            break
+    return symbol_ids
+
+
+def _symbol_context(result: dict[str, Any], db: Any | None) -> list[str]:
+    if db is None or result.get("id") is None:
+        return []
+    try:
+        chunk = db.get_chunk(result["id"])
+    except Exception:
+        return []
+    if not chunk:
+        return []
+
+    context: list[str] = []
+    for symbol_id in _parse_symbol_ids(chunk.get("symbol_ids")):
+        try:
+            symbol = db.get_symbol(symbol_id)
+        except Exception:
+            continue
+        if not symbol:
+            continue
+        name = str(symbol.get("name", "")).strip()
+        scope = str(symbol.get("scope", "")).strip()
+        qualified_name = f"{scope}.{name}" if name and scope and scope not in {"(module)", "module"} else name
+        kind = str(symbol.get("kind", "symbol")).strip() or "symbol"
+        signature = " ".join(str(symbol.get("signature", "")).split())
+        label = f"{kind} {qualified_name}".strip()
+        if signature and signature != qualified_name:
+            label = f"{label} :: {signature}"
+        if label:
+            context.append(label)
+    return context
+
+
+def _line_range(result: dict[str, Any]) -> str:
+    start = result.get("start_line")
+    end = result.get("end_line")
+    if isinstance(start, int):
+        start += 1
+    if isinstance(end, int):
+        end += 1
+    if start is None and end is None:
+        return "unknown"
+    if end is None or end == start:
+        return str(start)
+    return f"{start}-{end}"
+
+
+def build_rerank_document(
+    result: dict[str, Any],
+    db: Any | None = None,
+    *,
+    max_chars: int = MAX_RERANK_DOCUMENT_CHARS,
+) -> str:
+    """Build one bounded reranker document with stable provenance context."""
+    symbols = _symbol_context(result, db)
+    lines = [
+        "[Tessera candidate]",
+        f"Project: {result.get('project_name') or result.get('project_id') or 'unknown'}",
+        f"Path: {result.get('file_path') or 'unknown'}",
+        f"Source: {result.get('source_type') or 'unknown'}",
+        f"Lines: {_line_range(result)}",
+    ]
+    if symbols:
+        lines.append(f"Symbols: {' | '.join(symbols)}")
+    if result.get("section_heading"):
+        lines.append(f"Section: {result['section_heading']}")
+    if result.get("key_path"):
+        lines.append(f"Key: {result['key_path']}")
+
+    content = str(result.get("content") or result.get("snippet") or "")
+    document = "\n".join([*lines, "", "Content:", content])
+    return document[: max(0, max_chars)]
+
+
+def build_rerank_documents(
+    results: list[dict[str, Any]],
+    db_by_project: dict[Any, Any],
+) -> list[str]:
+    """Build bounded documents for a federated candidate pool."""
+    return [build_rerank_document(result, db_by_project.get(result.get("project_id"))) for result in results]

--- a/src/tessera/rerank.py
+++ b/src/tessera/rerank.py
@@ -9,7 +9,10 @@ RERANK_POOL_MULTIPLIER = 3
 MAX_RERANK_POOL_SIZE = 50
 RERANK_FETCH_MULTIPLIER = 5
 MAX_RERANK_FETCH_SIZE = 250
-MAX_RERANK_DOCUMENT_CHARS = 4096
+# Approximate one 512-token cross-encoder context window at four characters
+# per token. Expanded pools divide a fixed visible-page context budget rather
+# than multiplying inference work by the candidate expansion factor.
+MAX_RERANK_DOCUMENT_CHARS = 2048
 MAX_RERANK_SYMBOLS = 8
 RERANK_POOL_SELECTION = "file_coverage_first"
 
@@ -39,6 +42,14 @@ def rerank_retrieval_budget(candidate_budget: int, *, reranker_active: bool) -> 
         candidate_budget,
         min(candidate_budget * RERANK_FETCH_MULTIPLIER, MAX_RERANK_FETCH_SIZE),
     )
+
+
+def rerank_document_budget(visible_limit: int, pool_size: int) -> int:
+    """Return a per-document cap that conserves total cross-encoder context."""
+    if visible_limit <= 0 or pool_size <= 0:
+        return 0
+    total_chars = visible_limit * MAX_RERANK_DOCUMENT_CHARS
+    return min(MAX_RERANK_DOCUMENT_CHARS, max(1, total_chars // pool_size))
 
 
 def _project_key(result: dict[str, Any]) -> tuple[str, Any]:
@@ -196,6 +207,15 @@ def build_rerank_document(
 def build_rerank_documents(
     results: list[dict[str, Any]],
     db_by_project: dict[Any, Any],
+    *,
+    max_chars: int = MAX_RERANK_DOCUMENT_CHARS,
 ) -> list[str]:
     """Build bounded documents for a federated candidate pool."""
-    return [build_rerank_document(result, db_by_project.get(result.get("project_id"))) for result in results]
+    return [
+        build_rerank_document(
+            result,
+            db_by_project.get(result.get("project_id")),
+            max_chars=max_chars,
+        )
+        for result in results
+    ]

--- a/src/tessera/search_trace.py
+++ b/src/tessera/search_trace.py
@@ -390,13 +390,29 @@ class FederatedSearchTrace:
     def record_project_union(self, results: list[dict[str, Any]]) -> None:
         self._record_results("project_union", results)
 
-    def record_rerank_pool(self, results: list[dict[str, Any]]) -> None:
+    def record_rerank_pool(
+        self,
+        results: list[dict[str, Any]],
+        *,
+        requested_size: int | None = None,
+        retrieval_size: int | None = None,
+        selection_policy: str | None = None,
+        document_char_limit: int | None = None,
+    ) -> None:
         self._record_results("rerank_pool", results)
         self.reranker.update({
             "status": "running",
             "pool_size": len(results),
             "pool_keys": [self.result_key(result) for result in results],
         })
+        if requested_size is not None:
+            self.reranker["requested_pool_size"] = requested_size
+        if retrieval_size is not None:
+            self.reranker["project_retrieval_size"] = retrieval_size
+        if selection_policy is not None:
+            self.reranker["selection_policy"] = selection_policy
+        if document_char_limit is not None:
+            self.reranker["document_char_limit"] = document_char_limit
 
     def record_rerank_result(
         self,

--- a/src/tessera/server/tools/_search.py
+++ b/src/tessera/server/tools/_search.py
@@ -6,6 +6,14 @@ import logging
 from fastmcp import FastMCP
 
 from ...embeddings import EmbeddingUnavailableError
+from ...rerank import (
+    MAX_RERANK_DOCUMENT_CHARS,
+    RERANK_POOL_SELECTION,
+    build_rerank_documents,
+    rerank_candidate_budget,
+    rerank_retrieval_budget,
+    select_rerank_candidates,
+)
 from ...search import (
     SearchType,
     doc_search,
@@ -81,7 +89,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                 E.g., max_depth=1 shows only the immediate containing function/class.
         """
         # Import state at call time to get current values (globals are mutable)
-        from .._state import _embedding_client
+        from .._state import _embedding_client, _reranker
 
         scope, err = _check_session({"session_id": session_id}, "project")
         if err:
@@ -143,6 +151,14 @@ def register_search_tools(mcp: FastMCP) -> None:
 
             # Use model profile's keyword weight unless explicit rrf_weights provided
             profile_kw_weight = _model_profile.hybrid_keyword_weight if _model_profile and not rrf_weights else None
+            candidate_limit = rerank_candidate_budget(
+                limit,
+                reranker_active=_reranker is not None,
+            )
+            retrieval_limit = rerank_retrieval_budget(
+                candidate_limit,
+                reranker_active=_reranker is not None,
+            )
 
             federated_trace = (
                 FederatedSearchTrace(query=query, limit=limit)
@@ -158,7 +174,7 @@ def register_search_tools(mcp: FastMCP) -> None:
             tasks = [
                 asyncio.to_thread(
                     hybrid_search, query, query_embedding, db,
-                    None, limit, source_type_filter,
+                    None, retrieval_limit, source_type_filter,
                     search_types, advanced_fts, rrf_weights,
                     keyword_weight=profile_kw_weight,
                     trace=project_trace,
@@ -196,14 +212,23 @@ def register_search_tools(mcp: FastMCP) -> None:
                 federated_trace.record_project_union(all_results)
 
             # Post-RRF reranking via cross-encoder (if available)
-            from .._state import _reranker
+            db_by_pid = {pid: db for pid, _pn, db in dbs}
             if _reranker and all_results:
                 try:
-                    # Rerank top candidates (take more than limit to give reranker room)
-                    rerank_pool = all_results[:limit * 3]
+                    rerank_pool = select_rerank_candidates(all_results, candidate_limit)
                     if federated_trace is not None:
-                        federated_trace.record_rerank_pool(rerank_pool)
-                    docs = [r.get("content", r.get("snippet", "")) for r in rerank_pool]
+                        federated_trace.record_rerank_pool(
+                            rerank_pool,
+                            requested_size=candidate_limit,
+                            retrieval_size=retrieval_limit,
+                            selection_policy=RERANK_POOL_SELECTION,
+                            document_char_limit=MAX_RERANK_DOCUMENT_CHARS,
+                        )
+                    docs = await asyncio.to_thread(
+                        build_rerank_documents,
+                        rerank_pool,
+                        db_by_pid,
+                    )
                     reranked = await asyncio.to_thread(_reranker.rerank, query, docs, limit)
                     all_results = [rerank_pool[idx] for idx, _score in reranked]
                     if federated_trace is not None:
@@ -235,7 +260,6 @@ def register_search_tools(mcp: FastMCP) -> None:
                 snippet_embed_fn = _embedding_client.embed
 
             # Extract best-matching snippets with ancestor context
-            db_by_pid = {pid: db for pid, _pn, db in dbs}
             for r in all_results:
                 if r.get("content"):
                     # start_line is 0-based from chunker; convert to 1-based for display
@@ -248,7 +272,12 @@ def register_search_tools(mcp: FastMCP) -> None:
 
                     # Look up ancestor symbols for nesting context
                     file_id = r.get("file_id")
-                    result_db = db_by_pid.get(r.get("project_id"))
+                    result_project_id = r.get("project_id")
+                    result_db = (
+                        db_by_pid.get(result_project_id)
+                        if isinstance(result_project_id, int)
+                        else None
+                    )
                     ancestors = []
                     if file_id and result_db and abs_match > 0:
                         ancestors = result_db.get_ancestor_symbols(file_id, abs_match)

--- a/src/tessera/server/tools/_search.py
+++ b/src/tessera/server/tools/_search.py
@@ -7,10 +7,10 @@ from fastmcp import FastMCP
 
 from ...embeddings import EmbeddingUnavailableError
 from ...rerank import (
-    MAX_RERANK_DOCUMENT_CHARS,
     RERANK_POOL_SELECTION,
     build_rerank_documents,
     rerank_candidate_budget,
+    rerank_document_budget,
     rerank_retrieval_budget,
     select_rerank_candidates,
 )
@@ -216,18 +216,20 @@ def register_search_tools(mcp: FastMCP) -> None:
             if _reranker and all_results:
                 try:
                     rerank_pool = select_rerank_candidates(all_results, candidate_limit)
+                    document_char_limit = rerank_document_budget(limit, len(rerank_pool))
                     if federated_trace is not None:
                         federated_trace.record_rerank_pool(
                             rerank_pool,
                             requested_size=candidate_limit,
                             retrieval_size=retrieval_limit,
                             selection_policy=RERANK_POOL_SELECTION,
-                            document_char_limit=MAX_RERANK_DOCUMENT_CHARS,
+                            document_char_limit=document_char_limit,
                         )
                     docs = await asyncio.to_thread(
                         build_rerank_documents,
                         rerank_pool,
                         db_by_pid,
+                        max_chars=document_char_limit,
                     )
                     reranked = await asyncio.to_thread(_reranker.rerank, query, docs, limit)
                     all_results = [rerank_pool[idx] for idx, _score in reranked]

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -6,12 +6,14 @@ import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastmcp import Client
+from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 
 from tessera.db import GlobalDB, ProjectDB
 from tessera.indexer import IndexStats
+from tessera.server import _state as server_state
 from tessera.server import create_server
+from tessera.server.tools._search import register_search_tools
 
 
 @pytest.fixture
@@ -104,6 +106,82 @@ class TestSearchTool:
         assert trace["schema_version"] == "1.0"
         assert trace["query"] == "trace fixture"
         assert trace["reranker"]["status"] == "skipped"
+
+    async def test_reranker_can_promote_candidate_beyond_visible_limit(self):
+        """The project search must fill the nominal rerank pool, not one page."""
+        candidates = [
+            {
+                "id": chunk_id,
+                "file_path": f"src/candidate_{chunk_id}.py",
+                "start_line": chunk_id,
+                "end_line": chunk_id,
+                "content": "needle target" if chunk_id == 3 else f"distractor {chunk_id}",
+                "score": 1.0 / chunk_id,
+                "source_type": "code",
+            }
+            for chunk_id in range(1, 7)
+        ]
+
+        class PromotingReranker:
+            def __init__(self):
+                self.documents = []
+
+            def rerank(self, _query, documents, top_k=10):
+                self.documents = documents
+                target = next(index for index, doc in enumerate(documents) if "needle target" in doc)
+                remainder = [index for index in range(len(documents)) if index != target]
+                return [(index, 1.0 - rank / 10) for rank, index in enumerate([target, *remainder][:top_k])]
+
+        reranker = PromotingReranker()
+
+        def fake_hybrid_search(*args, **_kwargs):
+            requested_limit = args[4]
+            return [dict(candidate) for candidate in candidates[:requested_limit]]
+
+        mcp = FastMCP("two-stage-fixture")
+        register_search_tools(mcp)
+        with (
+            patch("tessera.server.tools._search._get_project_dbs", return_value=[(7, "fixture", object())]),
+            patch("tessera.server.tools._search.hybrid_search", side_effect=fake_hybrid_search) as search_mock,
+            patch.object(server_state, "_embedding_client", None),
+            patch.object(server_state, "_reranker", reranker),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool("search", {"query": "find needle", "limit": 2})
+
+        payload = json.loads(result.content[0].text)
+        assert search_mock.call_args.args[4] == 30
+        assert [item["id"] for item in payload] == [3, 1]
+        assert len(reranker.documents) == 6
+
+    async def test_no_reranker_keeps_visible_retrieval_limit_and_order(self):
+        candidates = [
+            {
+                "id": chunk_id,
+                "file_path": f"src/candidate_{chunk_id}.py",
+                "content": f"candidate {chunk_id}",
+                "score": 1.0 / chunk_id,
+            }
+            for chunk_id in range(1, 5)
+        ]
+
+        def fake_hybrid_search(*args, **_kwargs):
+            return [dict(candidate) for candidate in candidates[:args[4]]]
+
+        mcp = FastMCP("no-reranker-fixture")
+        register_search_tools(mcp)
+        with (
+            patch("tessera.server.tools._search._get_project_dbs", return_value=[(7, "fixture", object())]),
+            patch("tessera.server.tools._search.hybrid_search", side_effect=fake_hybrid_search) as search_mock,
+            patch.object(server_state, "_embedding_client", None),
+            patch.object(server_state, "_reranker", None),
+        ):
+            async with Client(mcp) as client:
+                result = await client.call_tool("search", {"query": "candidate", "limit": 2})
+
+        payload = json.loads(result.content[0].text)
+        assert search_mock.call_args.args[4] == 2
+        assert [item["id"] for item in payload] == [1, 2]
 
 
 class TestSymbolsTool:

--- a/tests/unit/test_rerank.py
+++ b/tests/unit/test_rerank.py
@@ -1,0 +1,120 @@
+"""Two-stage retrieval budget, diversity, and document invariants."""
+
+from tessera.rerank import (
+    MAX_RERANK_DOCUMENT_CHARS,
+    build_rerank_document,
+    rerank_candidate_budget,
+    rerank_retrieval_budget,
+    select_rerank_candidates,
+)
+
+
+def _candidate(
+    chunk_id: int,
+    path: str,
+    *,
+    project_id: int = 1,
+    file_id: int | None = None,
+) -> dict:
+    return {
+        "id": chunk_id,
+        "project_id": project_id,
+        "file_id": file_id,
+        "file_path": path,
+        "content": f"chunk {chunk_id}",
+        "score": 1.0 / chunk_id,
+    }
+
+
+def test_candidate_budget_expands_only_for_active_reranker() -> None:
+    assert rerank_candidate_budget(10, reranker_active=False) == 10
+    assert rerank_candidate_budget(10, reranker_active=True) == 30
+    assert rerank_candidate_budget(20, reranker_active=True) == 50
+    assert rerank_candidate_budget(100, reranker_active=True) == 100
+    assert rerank_candidate_budget(0, reranker_active=True) == 0
+    assert rerank_retrieval_budget(30, reranker_active=True) == 150
+    assert rerank_retrieval_budget(50, reranker_active=True) == 250
+    assert rerank_retrieval_budget(100, reranker_active=True) == 250
+    assert rerank_retrieval_budget(10, reranker_active=False) == 10
+
+
+def test_coverage_first_pool_preserves_order_and_then_allows_second_chunks() -> None:
+    results = [
+        _candidate(1, "src/a.py", file_id=10),
+        _candidate(2, "src/a.py", file_id=10),
+        _candidate(3, "src/b.py", file_id=20),
+        _candidate(4, "src/c.py", file_id=30),
+        _candidate(5, "src/b.py", file_id=20),
+    ]
+
+    assert [item["id"] for item in select_rerank_candidates(results, 3)] == [1, 3, 4]
+    assert [item["id"] for item in select_rerank_candidates(results, 5)] == [1, 3, 4, 2, 5]
+
+
+def test_file_identity_is_project_local_and_unknown_paths_do_not_collapse() -> None:
+    results = [
+        _candidate(1, "src/shared.py", project_id=10),
+        _candidate(1, "src/shared.py", project_id=20),
+        _candidate(2, "", project_id=10),
+        _candidate(3, "", project_id=10),
+    ]
+
+    assert [item["id"] for item in select_rerank_candidates(results, 4)] == [1, 1, 2, 3]
+
+
+class SymbolDB:
+    def get_chunk(self, _chunk_id):
+        return {"symbol_ids": '[4, 4, "bad", 9]'}
+
+    def get_symbol(self, symbol_id):
+        return {
+            4: {
+                "name": "search",
+                "kind": "method",
+                "scope": "SearchService",
+                "signature": "def search(self, query: str)",
+            },
+            9: {
+                "name": "SearchService",
+                "kind": "class",
+                "scope": "(module)",
+                "signature": "class SearchService",
+            },
+        }.get(symbol_id)
+
+
+def test_structured_document_includes_path_symbol_and_bounded_content() -> None:
+    result = {
+        "id": 7,
+        "project_name": "fixture",
+        "file_path": "src/search.py",
+        "source_type": "code",
+        "start_line": 9,
+        "end_line": 19,
+        "content": "x" * (MAX_RERANK_DOCUMENT_CHARS * 2),
+    }
+
+    document = build_rerank_document(result, SymbolDB())
+
+    assert len(document) == MAX_RERANK_DOCUMENT_CHARS
+    assert "Project: fixture" in document
+    assert "Path: src/search.py" in document
+    assert "Lines: 10-20" in document
+    assert "method SearchService.search :: def search(self, query: str)" in document
+    assert "class SearchService :: class SearchService" in document
+    assert "Content:\n" in document
+
+
+def test_structured_document_tolerates_missing_and_malformed_symbol_metadata() -> None:
+    class MalformedDB:
+        def get_chunk(self, _chunk_id):
+            return {"symbol_ids": "not-json"}
+
+    document = build_rerank_document(
+        {"id": 1, "content": "fallback", "file_path": "README.md"},
+        MalformedDB(),
+    )
+
+    assert "Path: README.md" in document
+    assert "Symbols:" not in document
+    assert document.endswith("fallback")

--- a/tests/unit/test_rerank.py
+++ b/tests/unit/test_rerank.py
@@ -4,6 +4,7 @@ from tessera.rerank import (
     MAX_RERANK_DOCUMENT_CHARS,
     build_rerank_document,
     rerank_candidate_budget,
+    rerank_document_budget,
     rerank_retrieval_budget,
     select_rerank_candidates,
 )
@@ -36,6 +37,13 @@ def test_candidate_budget_expands_only_for_active_reranker() -> None:
     assert rerank_retrieval_budget(50, reranker_active=True) == 250
     assert rerank_retrieval_budget(100, reranker_active=True) == 250
     assert rerank_retrieval_budget(10, reranker_active=False) == 10
+
+
+def test_document_budget_conserves_visible_page_context() -> None:
+    assert rerank_document_budget(10, 10) == MAX_RERANK_DOCUMENT_CHARS
+    assert rerank_document_budget(10, 30) == 682
+    assert rerank_document_budget(2, 6) == 682
+    assert rerank_document_budget(10, 0) == 0
 
 
 def test_coverage_first_pool_preserves_order_and_then_allows_second_chunks() -> None:

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -260,7 +260,13 @@ def test_federated_trace_attributes_projects_scores_and_rerank_pool() -> None:
 
     trace = FederatedSearchTrace(query="handler", limit=2)
     trace.record_project_union(union)
-    trace.record_rerank_pool(pool)
+    trace.record_rerank_pool(
+        pool,
+        requested_size=2,
+        retrieval_size=10,
+        selection_policy="file_coverage_first",
+        document_char_limit=4096,
+    )
     trace.record_rerank_result(pool, reranked, final)
     trace.record_final(final)
 
@@ -276,6 +282,10 @@ def test_federated_trace_attributes_projects_scores_and_rerank_pool() -> None:
         "output_rank": 1,
         "reranker_score": 0.9,
     }
+    assert trace.reranker["requested_pool_size"] == 2
+    assert trace.reranker["project_retrieval_size"] == 10
+    assert trace.reranker["selection_policy"] == "file_coverage_first"
+    assert trace.reranker["document_char_limit"] == 4096
     candidate_attribution = {
         candidate["key"]: candidate
         for candidate in trace.candidate_attribution()


### PR DESCRIPTION
## Status: do not merge

This is the completed PR-03 experiment from the retrieval-quality master plan. It validates the real candidate-pool defect and records two full six-repository treatments, but the production change fails the predeclared latency gate and is intentionally left as a draft.

## What it tests

- moves candidate budgeting before per-project retrieval;
- builds a bounded 3x cross-encoder pool from a bounded raw over-fetch;
- selects candidates coverage-first with second-chunk backfill;
- supplies bounded project/path/line/symbol context to the reranker;
- traces raw depth, pool size, diversity policy, and document budget;
- adds a red/green server fixture proving candidate 3 can be promoted with visible `limit=2` while the no-reranker path remains unchanged;
- adds the reproducible paired benchmark and predeclared experiment record.

## Result

Initial full-context treatment:

- macro MRR@10: `0.750000 -> 0.801190`;
- Top-1: `60.0% -> 73.3%`;
- p95: `3,406.24 ms -> 8,093.41 ms` (gate failed).

Context-conserving remediation (same model/pool/queries/gates):

- macro MRR@10: `0.750000 -> 0.758095`;
- paired 95% interval: `[-0.157381, +0.132778]`;
- Top-1: `60.0% -> 66.7%`; Top-10: `96.7% -> 100%`;
- p95: `2,824.68 ms -> 5,824.85 ms` (both latency gates failed);
- Hono MRR regressed by `0.354762`;
- coverage-first alone reduced macro MRR by `0.030238`.

The exact remediation run was host-load contaminated (another local model held ~31% RAM and swap reached ~30.7 GiB), but it still fails the declared wall-clock contract. The isolated label-free inference check supports the token-volume mechanism; it does not override the corpus gate. No sealed holdout was opened and no further context constant was tuned after seeing these results.

## Validation

- `545 passed` across the complete unit suite plus server/search/graph integration suites;
- changed-file Ruff: pass;
- targeted Pyright: 0 errors;
- strict MkDocs: pass;
- deterministic before-state fixture failed because project retrieval received 2; after-state receives the declared raw budget and promotes candidate 3.

Full report: `docs/benchmark-two-stage-retrieval-2026-07-14.md`

Artifacts:

- `benchmarks/development-two-stage-initial-2026-07-14.json`
- `benchmarks/development-two-stage-2026-07-14.json`

The repository-wide `ruff check .` also surfaces 117 pre-existing findings in legacy benchmark/spike files; all files changed by this PR pass.
