### PR TITLE
Add searchable file/path candidate channel

### DIFF
--- a/docs/plans/retrieval-quality-master-plan/PR-04.md
+++ b/docs/plans/retrieval-quality-master-plan/PR-04.md
@@ -1,0 +1,118 @@
+# PR-04 — Searchable File/Path Candidate Channel
+
+**Date declared:** 2026-07-14
+
+**Parent revision:** `origin/develop` at `3a892c3`
+
+**Evidence class:** retrieval quality, deterministic correctness, and
+performance/operations
+
+**Status:** Hypothesis and gates frozen before treatment results
+
+## Hypothesis
+
+Tessera cannot currently retrieve a file from its path alone. The
+`chunks_fts.file_path` column is `UNINDEXED`, so a query term that is present in
+the path but absent from chunk bodies contributes no lexical candidate. A
+separate, file-level path index should recover those files across identifier
+styles and then contribute one representative chunk through the existing
+ranked-channel/RRF interface.
+
+This change is structural. It does not infer path intent from development
+queries, add repository- or language-specific terms, or apply a scalar filename
+boost after fusion.
+
+## Frozen treatment
+
+- Add one FTS5 row per indexed file, maintained transactionally with the
+  `files` table and backfilled by a schema migration.
+- Store six views: normalized path, basename, extensionless basename,
+  directory components, dotted module path, and identifier aliases.
+- Identifier normalization preserves the original case-folded component and
+  adds deterministic camel/snake/kebab/digit pieces. Query normalization uses
+  the same transformation, OR-combines literal tokens, and caps input at 32
+  unique tokens for bounded SQL work.
+- Rank inside the path channel with FTS5 BM25 using fixed structural weights:
+  path `4`, basename `6`, stem `6`, directories `1`, module `2`, aliases `1`.
+  These values express field specificity and will not be searched or changed
+  after development results are inspected.
+- Fuse the path list with weighted RRF at weight `1.2`, equal to the existing
+  semantic channel. A file/path match is file-specific evidence; it receives no
+  post-fusion coefficient or language/query exception.
+- Emit at most one deterministic representative chunk per matched file: the
+  earliest chunk satisfying the requested source-type filter, ordered by start
+  line and chunk ID.
+- Run the channel only when lexical retrieval is routed and expose
+  `enable_path_search=False` solely as the paired ablation/rollback switch.
+- Do not demote or specially handle `vendor`, generated, test, example, or
+  deeply nested paths. Existing indexing ignore rules remain authoritative.
+
+## Deterministic red/green invariants
+
+Before the treatment, each path-only query must miss through content FTS. After
+the treatment:
+
+- camel, snake, and kebab spellings resolve the same generic filename;
+- punctuation and case do not prevent matching;
+- duplicate basenames remain distinct and deterministically ordered;
+- indexed generated/vendor paths remain searchable;
+- code and Markdown source filters select only eligible representative chunks;
+- file updates remain single-row/idempotent, deletion removes the path row, and
+  a version-3 database is backfilled on open;
+- disabling the path channel preserves control ordering.
+
+Fixtures use invented paths and opaque bodies. They are not copied from the
+development or legacy benchmark queries.
+
+## Development experiment
+
+Run the frozen six-repository, 30-query public development corpus (Python,
+TypeScript/JavaScript, PHP, Go, Swift, Ruby; code, Markdown/document, and mixed
+queries). For every case, alternate/rotate two engines on the same migrated
+index and embedding:
+
+1. `content_semantic_control`: path channel disabled.
+2. `path_channel_treatment`: path channel enabled with the constants above.
+
+Record channel and union Recall@10/20/50, file-level MRR@10 and Top-1/3/10,
+ordered files, per-repository paired deltas, protected language/content
+segments, query p50/p95, path-only SQL latency, path-index bytes, and path-index
+build time. Use seed `1729` and 10,000 repository-level paired bootstrap
+samples. Do not run or inspect the sealed holdout.
+
+## Predeclared gates
+
+All gates are conjunctive for default-on promotion:
+
+1. **Correctness:** every generic invariant passes, including migration,
+   incremental maintenance, source filtering, and the disabled-channel control.
+2. **Candidate recall:** development union Recall@10 improves and the lower
+   bound of the repository-level paired 95% interval is greater than zero. The
+   already-ceilinged Recall@20/50 values may not decline.
+3. **Quality:** the lower bound of the paired macro-repository MRR@10 delta is at
+   least `-0.02`; no protected language or content segment with five or more
+   cases loses more than `0.05` absolute MRR@10.
+4. **Query operations:** isolated warm path-search p95 is at most `10 ms`; paired
+   end-to-end treatment p95 is no more than `10 ms` slower and no more than
+   `1.25x` control. Host-load contamination must be reported rather than
+   rationalized away.
+5. **Index operations:** the path index consumes no more than the greater of
+   `2 MiB` or `10%` of the final SQLite index, and isolated path-index build time
+   is no more than `10%` of full repository indexing time.
+6. **Regressions:** relevant unit/integration suites, lint, type checking, and
+   strict documentation build pass. Default results with no path matches are
+   order-equivalent to the disabled control.
+
+If candidate recall is positive but its interval includes zero, the result is
+inconclusive. The PR remains draft/default-disabled or is closed; the interval
+will not be weakened and constants will not be retuned on these 30 queries.
+
+## Rollback and exclusions
+
+`enable_path_search=False` removes the channel without deleting data. The FTS
+table is derived data and may be dropped/rebuilt from `files`; the authoritative
+file/chunk schema is unchanged.
+
+This PR excludes symbol/signature indexing, hierarchical file-to-chunk
+aggregation, learned fusion, path-intent classification, query expansion based
+on observed benchmark misses, and changes to the embedding or reranking models.

--- a/scripts/benchmark_governance.py
+++ b/scripts/benchmark_governance.py
@@ -592,6 +592,94 @@ def paired_bootstrap_interval(
     }
 
 
+def paired_candidate_recall_interval(
+    rows: list[dict[str, Any]],
+    baseline_engine: str,
+    treatment_engine: str,
+    *,
+    cutoff: int,
+    candidate_set: str = "union",
+    iterations: int = 10_000,
+    seed: int = 1729,
+) -> dict[str, Any]:
+    """Return a paired repository-bootstrap interval for candidate Recall@K."""
+    if cutoff < 1:
+        raise CorpusValidationError("Candidate recall cutoff must be positive")
+    if iterations < 1:
+        raise CorpusValidationError("Bootstrap iterations must be positive")
+
+    baseline = {
+        _case_key(row): row
+        for row in rows
+        if row.get("engine") == baseline_engine and row.get("supported", True)
+    }
+    treatment = {
+        _case_key(row): row
+        for row in rows
+        if row.get("engine") == treatment_engine and row.get("supported", True)
+    }
+    if baseline.keys() != treatment.keys():
+        missing_treatment = sorted(baseline.keys() - treatment.keys())
+        missing_baseline = sorted(treatment.keys() - baseline.keys())
+        raise CorpusValidationError(
+            f"Paired engines cover different cases; missing treatment={missing_treatment}, "
+            f"missing baseline={missing_baseline}"
+        )
+    if not baseline:
+        raise CorpusValidationError("Paired comparison has no shared supported cases")
+
+    def recall(row: dict[str, Any]) -> float:
+        diagnostics = row.get("candidate_diagnostics") or {}
+        if candidate_set == "union":
+            candidate = diagnostics.get("union") or {}
+        else:
+            candidate = (diagnostics.get("channels") or {}).get(candidate_set) or {}
+        value = (candidate.get("recall_at_k") or {}).get(str(cutoff))
+        if value is None:
+            raise CorpusValidationError(
+                f"Missing {candidate_set} candidate Recall@{cutoff} for {_case_key(row)}"
+            )
+        return float(value)
+
+    by_repository: dict[str, list[tuple[float, float]]] = defaultdict(list)
+    for key in sorted(baseline):
+        by_repository[key[0]].append((recall(baseline[key]), recall(treatment[key])))
+    baseline_repo = {
+        repository: fmean(pair[0] for pair in pairs)
+        for repository, pairs in by_repository.items()
+    }
+    treatment_repo = {
+        repository: fmean(pair[1] for pair in pairs)
+        for repository, pairs in by_repository.items()
+    }
+    repository_deltas = [
+        treatment_repo[name] - baseline_repo[name]
+        for name in sorted(by_repository)
+    ]
+    rng = random.Random(seed)
+    sample_size = len(repository_deltas)
+    samples = [
+        fmean(repository_deltas[rng.randrange(sample_size)] for _ in range(sample_size))
+        for _ in range(iterations)
+    ]
+    return {
+        "metric": f"macro_{candidate_set}_candidate_recall_at_{cutoff}_delta",
+        "baseline_engine": baseline_engine,
+        "treatment_engine": treatment_engine,
+        "repositories": sample_size,
+        "paired_queries": len(baseline),
+        "baseline": round(fmean(baseline_repo.values()), 6),
+        "treatment": round(fmean(treatment_repo.values()), 6),
+        "delta": round(fmean(repository_deltas), 6),
+        "confidence": 0.95,
+        "ci_lower": round(_percentile(samples, 0.025), 6),
+        "ci_upper": round(_percentile(samples, 0.975), 6),
+        "bootstrap_unit": "repository",
+        "iterations": iterations,
+        "seed": seed,
+    }
+
+
 def build_run_metadata(
     manifest_path: Path,
     split: str,

--- a/scripts/benchmark_path_channel.py
+++ b/scripts/benchmark_path_channel.py
@@ -271,6 +271,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--reindex", action="store_true")
     parser.add_argument("--path-latency-repetitions", type=int, default=3)
     parser.add_argument("--compare-baseline", type=Path, default=DEFAULT_FROZEN_BASELINE)
+    parser.add_argument("--skip-baseline-comparison", action="store_true")
     parser.add_argument("--output", type=Path)
     return parser.parse_args()
 
@@ -447,7 +448,7 @@ def main() -> int:
         control_rows = [row for row in rows if row["engine"] == CONTROL_ENGINE]
         baseline_comparison = (
             _compare_baseline(control_rows, args.compare_baseline)
-            if args.compare_baseline
+            if args.compare_baseline and not args.skip_baseline_comparison
             else None
         )
         metadata = build_run_metadata(

--- a/scripts/benchmark_path_channel.py
+++ b/scripts/benchmark_path_channel.py
@@ -1,0 +1,526 @@
+"""Run the predeclared PR-04 file/path candidate-channel comparison.
+
+The public development corpus is used only after the path representation,
+ranking constants, and gates in PR-04.md have been frozen. Control and
+treatment run on the same index; the sole retrieval difference is the explicit
+``enable_path_search`` ablation.
+
+Example:
+    uv run python scripts/benchmark_path_channel.py --reindex \
+      --output benchmarks/development-path-channel-2026-07-14.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from benchmark_development import (  # noqa: E402
+    BASELINE_MODEL,
+    BASELINE_SEED,
+    DEFAULT_INDEX_ROOT,
+    TOP_K,
+    _compare_baseline,
+    _dedupe_paths,
+    _git_revision,
+    _index_repository,
+    _latency_metrics,
+    _source_filter,
+    _tracked_worktree_changes,
+    rank_expected,
+)
+from benchmark_governance import (  # noqa: E402
+    DEFAULT_CHECKOUT_ROOT,
+    DEFAULT_MANIFEST,
+    build_run_metadata,
+    checkout_repository,
+    load_manifest,
+    load_queries,
+    macro_per_repository,
+    manifest_digest,
+    paired_bootstrap_interval,
+    paired_candidate_recall_interval,
+    protected_segment_metrics,
+    repositories_for_split,
+    retrieval_metrics,
+    validate_labels_against_checkout,
+)
+
+from tessera.db import ProjectDB  # noqa: E402
+from tessera.db._utils import PATH_QUERY_TOKEN_LIMIT  # noqa: E402
+from tessera.embeddings import FastembedClient  # noqa: E402
+from tessera.search import DEFAULT_RRF_WEIGHTS, hybrid_search  # noqa: E402
+from tessera.search_trace import (  # noqa: E402
+    SearchTrace,
+    candidate_retrieval_diagnostics,
+    stratified_candidate_diagnostics,
+)
+
+CONTROL_ENGINE = "content_semantic_control"
+TREATMENT_ENGINE = "path_channel_treatment"
+ENGINES = [CONTROL_ENGINE, TREATMENT_ENGINE]
+DEFAULT_FROZEN_BASELINE = REPO_ROOT / "benchmarks" / "development-baseline-2026-07-14.json"
+PATH_LATENCY_P95_BUDGET_MS = 10.0
+END_TO_END_ADDED_P95_BUDGET_MS = 10.0
+END_TO_END_P95_RATIO_BUDGET = 1.25
+PATH_INDEX_ABSOLUTE_BUDGET_BYTES = 2 * 1024 * 1024
+PATH_INDEX_RELATIVE_BUDGET = 0.10
+PATH_BUILD_TIME_RATIO_BUDGET = 0.10
+
+
+def _host_snapshot() -> dict[str, Any]:
+    load = os.getloadavg() if hasattr(os, "getloadavg") else (None, None, None)
+    return {
+        "load_average_1m": load[0],
+        "load_average_5m": load[1],
+        "load_average_15m": load[2],
+        "logical_cpu_count": os.cpu_count(),
+    }
+
+
+def _database_storage(database: ProjectDB) -> dict[str, Any]:
+    """Measure the FTS shadow tables and complete SQLite allocation."""
+    database.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchall()
+    page_size = int(database.conn.execute("PRAGMA page_size").fetchone()[0])
+    page_count = int(database.conn.execute("PRAGMA page_count").fetchone()[0])
+    path_bytes = int(
+        database.conn.execute(
+            "SELECT COALESCE(SUM(pgsize), 0) FROM dbstat WHERE name GLOB 'file_paths_fts*'"
+        ).fetchone()[0]
+    )
+    return {
+        "database_bytes": page_size * page_count,
+        "path_index_bytes": path_bytes,
+        "path_index_rows": int(
+            database.conn.execute("SELECT COUNT(*) FROM file_paths_fts").fetchone()[0]
+        ),
+    }
+
+
+def _measure_path_rebuild(database: ProjectDB) -> dict[str, Any]:
+    started = time.perf_counter()
+    indexed = database.rebuild_file_path_index()
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    return {
+        "path_build_ms": round(elapsed_ms, 3),
+        "paths_indexed": indexed,
+        **_database_storage(database),
+    }
+
+
+def _path_latency_samples(
+    case: dict[str, Any],
+    database: ProjectDB,
+    repetitions: int,
+) -> list[float]:
+    samples: list[float] = []
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        database.path_search(
+            case["query"],
+            limit=TOP_K,
+            source_type=_source_filter(case["category"]),
+        )
+        samples.append(round((time.perf_counter() - started) * 1000, 6))
+    return samples
+
+
+def _run_case(
+    case: dict[str, Any],
+    database: ProjectDB,
+    embedder: FastembedClient,
+    engine: str,
+    *,
+    path_latency_repetitions: int,
+) -> dict[str, Any]:
+    enable_path_search = engine == TREATMENT_ENGINE
+    started = time.perf_counter()
+    embedding_started = time.perf_counter()
+    embedding = np.asarray(embedder.embed_query(case["query"]), dtype=np.float32)
+    embedding_ms = (time.perf_counter() - embedding_started) * 1000
+    search_started = time.perf_counter()
+    hits = hybrid_search(
+        case["query"],
+        embedding,
+        database,
+        graph=None,
+        limit=TOP_K,
+        source_type=_source_filter(case["category"]),
+        file_dedup=True,
+        enable_path_search=enable_path_search,
+    )
+    search_ms = (time.perf_counter() - search_started) * 1000
+    latency_ms = (time.perf_counter() - started) * 1000
+
+    trace = SearchTrace(project_name=case["repository"])
+    traced_hits = hybrid_search(
+        case["query"],
+        embedding,
+        database,
+        graph=None,
+        limit=TOP_K,
+        source_type=_source_filter(case["category"]),
+        file_dedup=True,
+        trace=trace,
+        enable_path_search=enable_path_search,
+    )
+    if [hit["id"] for hit in traced_hits] != [hit["id"] for hit in hits]:
+        raise RuntimeError(
+            f"Tracing changed result order for {case['repository']}/{case['case_id']}/{engine}"
+        )
+
+    paths = _dedupe_paths(hits)[:TOP_K]
+    rank = rank_expected(paths, case["expected_files"])
+    diagnostics = candidate_retrieval_diagnostics(trace, case["expected_files"])
+    return {
+        **case,
+        "engine": engine,
+        "supported": True,
+        "rank": rank,
+        "reciprocal_rank": round(1.0 / rank, 6) if rank else 0.0,
+        "top_files": paths,
+        "latency_ms": round(latency_ms, 3),
+        "embedding_ms": round(embedding_ms, 3),
+        "search_ms": round(search_ms, 3),
+        "path_latency_samples_ms": _path_latency_samples(
+            case,
+            database,
+            path_latency_repetitions,
+        )
+        if enable_path_search
+        else [],
+        "candidate_diagnostics": diagnostics,
+        "trace_attribution_complete": diagnostics["attribution_complete"],
+    }
+
+
+def _protected_deltas(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for dimension in ("language", "content_type"):
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            if row.get(dimension):
+                grouped[str(row[dimension])].append(row)
+        output[dimension] = {}
+        for value, segment in sorted(grouped.items()):
+            control = [row for row in segment if row["engine"] == CONTROL_ENGINE]
+            treatment = [row for row in segment if row["engine"] == TREATMENT_ENGINE]
+            if not control or len(control) != len(treatment):
+                continue
+            control_metrics = retrieval_metrics(control)
+            treatment_metrics = retrieval_metrics(treatment)
+            output[dimension][value] = {
+                "paired_queries": len(control),
+                "control_mrr_at_10": control_metrics["mrr_at_10"],
+                "treatment_mrr_at_10": treatment_metrics["mrr_at_10"],
+                "delta_mrr_at_10": round(
+                    treatment_metrics["mrr_at_10"] - control_metrics["mrr_at_10"],
+                    6,
+                ),
+            }
+    return output
+
+
+def _index_operations(repositories: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    rows = [metadata["index"] for metadata in repositories.values()]
+    uncached = all(not row.get("cached", False) and row.get("index_ms") is not None for row in rows)
+    full_index_ms = sum(float(row.get("index_ms", 0.0)) for row in rows)
+    path_build_ms = sum(float(row["path_build_ms"]) for row in rows)
+    database_bytes = sum(int(row["database_bytes"]) for row in rows)
+    path_index_bytes = sum(int(row["path_index_bytes"]) for row in rows)
+    return {
+        "repositories_measured": len(rows),
+        "all_repositories_cold_indexed": uncached,
+        "full_index_ms": round(full_index_ms, 3),
+        "path_build_ms": round(path_build_ms, 3),
+        "path_build_time_ratio": round(path_build_ms / full_index_ms, 6)
+        if full_index_ms
+        else None,
+        "database_bytes": database_bytes,
+        "path_index_bytes": path_index_bytes,
+        "path_index_ratio": round(path_index_bytes / database_bytes, 6)
+        if database_bytes
+        else None,
+        "path_index_budget_bytes": max(
+            PATH_INDEX_ABSOLUTE_BUDGET_BYTES,
+            int(database_bytes * PATH_INDEX_RELATIVE_BUDGET),
+        ),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--repository", action="append", help="Development repository id; repeat as needed")
+    parser.add_argument("--tier", choices=["quick", "standard", "full"], default="quick")
+    parser.add_argument("--checkout-root", type=Path, default=DEFAULT_CHECKOUT_ROOT)
+    parser.add_argument("--index-root", type=Path, default=DEFAULT_INDEX_ROOT)
+    parser.add_argument("--reindex", action="store_true")
+    parser.add_argument("--path-latency-repetitions", type=int, default=3)
+    parser.add_argument("--compare-baseline", type=Path, default=DEFAULT_FROZEN_BASELINE)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.path_latency_repetitions < 1:
+        raise SystemExit("--path-latency-repetitions must be positive")
+    manifest = load_manifest(args.manifest)
+    available = {
+        repository["id"]: repository
+        for repository in repositories_for_split(manifest, "development")
+    }
+    selected_ids = args.repository or list(available)
+    unknown = sorted(set(selected_ids) - available.keys())
+    if unknown:
+        raise SystemExit(f"Unknown development repositories: {', '.join(unknown)}")
+    if _tracked_worktree_changes(REPO_ROOT):
+        raise SystemExit(
+            "Path-channel benchmarks require a clean tracked Tessera worktree so the revision identifies the code exactly"
+        )
+
+    tessera_revision = _git_revision(REPO_ROOT)
+    corpus_digest = manifest_digest(args.manifest)
+    host_start = _host_snapshot()
+    embedder = FastembedClient(model_name=BASELINE_MODEL)
+    _ = embedder.embed_query("path-channel benchmark warmup")
+
+    revisions: dict[str, str] = {}
+    repository_metadata: dict[str, dict[str, Any]] = {}
+    databases: dict[str, ProjectDB] = {}
+    cases: list[dict[str, Any]] = []
+    try:
+        for repository_id in selected_ids:
+            repository = available[repository_id]
+            checkout = checkout_repository(repository, args.checkout_root)
+            repository_cases = load_queries(manifest, repository_id, args.tier)
+            validate_labels_against_checkout(repository, repository_cases, checkout)
+            revision = _git_revision(checkout)
+            revisions[repository_id] = revision
+            database, index_metadata = _index_repository(
+                repository,
+                checkout,
+                embedder,
+                args.index_root,
+                tessera_revision,
+                corpus_digest,
+                reindex=args.reindex,
+            )
+            path_index_metadata = _measure_path_rebuild(database)
+            database.path_search("path channel warmup", limit=TOP_K)
+            databases[repository_id] = database
+            repository_metadata[repository_id] = {
+                "repository_url": repository["repository_url"],
+                "revision": revision,
+                "license": repository["license"],
+                "languages": repository["languages"],
+                "content_types": repository["content_types"],
+                "index": {**index_metadata, **path_index_metadata},
+            }
+            cases.extend(repository_cases)
+
+        rows: list[dict[str, Any]] = []
+        total = len(cases) * len(ENGINES)
+        completed = 0
+        for case_index, case in enumerate(cases):
+            offset = case_index % len(ENGINES)
+            run_order = ENGINES[offset:] + ENGINES[:offset]
+            by_engine: dict[str, dict[str, Any]] = {}
+            for engine in run_order:
+                result = _run_case(
+                    case,
+                    databases[case["repository"]],
+                    embedder,
+                    engine,
+                    path_latency_repetitions=args.path_latency_repetitions,
+                )
+                by_engine[engine] = result
+                completed += 1
+                rank = result["rank"] if result["rank"] is not None else "MISS"
+                print(f"[{completed}/{total}] {case['repository']} / {case['case_id']} / {engine}: {rank}")
+            rows.extend(by_engine[engine] for engine in ENGINES)
+
+        macro = macro_per_repository(rows)
+        latency = {
+            engine: _latency_metrics([row for row in rows if row["engine"] == engine])
+            for engine in ENGINES
+        }
+        search_latency = {
+            engine: _latency_metrics(
+                [
+                    {"latency_ms": row["search_ms"]}
+                    for row in rows
+                    if row["engine"] == engine
+                ]
+            )
+            for engine in ENGINES
+        }
+        path_samples = [
+            {"latency_ms": sample}
+            for row in rows
+            if row["engine"] == TREATMENT_ENGINE
+            for sample in row["path_latency_samples_ms"]
+        ]
+        path_latency = _latency_metrics(path_samples)
+        paired_mrr = paired_bootstrap_interval(
+            rows,
+            CONTROL_ENGINE,
+            TREATMENT_ENGINE,
+            seed=BASELINE_SEED,
+        )
+        paired_candidate = {
+            str(cutoff): paired_candidate_recall_interval(
+                rows,
+                CONTROL_ENGINE,
+                TREATMENT_ENGINE,
+                cutoff=cutoff,
+                seed=BASELINE_SEED,
+            )
+            for cutoff in (10, 20, 50)
+        }
+        protected_deltas = _protected_deltas(rows)
+        index_operations = _index_operations(repository_metadata)
+        control_p95 = latency[CONTROL_ENGINE]["p95_ms"]
+        treatment_p95 = latency[TREATMENT_ENGINE]["p95_ms"]
+        protected_regressions = [
+            f"{dimension}/{value}"
+            for dimension, segments in protected_deltas.items()
+            for value, metrics in segments.items()
+            if metrics["paired_queries"] >= 5 and metrics["delta_mrr_at_10"] < -0.05
+        ]
+        gates = {
+            "candidate_recall_at_10_point_delta_positive": paired_candidate["10"]["delta"] > 0,
+            "candidate_recall_at_10_ci_lower_positive": paired_candidate["10"]["ci_lower"] > 0,
+            "candidate_recall_at_20_non_negative": paired_candidate["20"]["delta"] >= 0,
+            "candidate_recall_at_50_non_negative": paired_candidate["50"]["delta"] >= 0,
+            "paired_macro_mrr_ci_lower_at_least_minus_0_02": paired_mrr["ci_lower"] >= -0.02,
+            "protected_segments_within_minus_0_05": not protected_regressions,
+            "all_candidate_traces_complete": all(row["trace_attribution_complete"] for row in rows),
+            "path_search_p95_at_most_10_ms": path_latency["p95_ms"] <= PATH_LATENCY_P95_BUDGET_MS,
+            "end_to_end_added_p95_at_most_10_ms": (
+                treatment_p95 - control_p95 <= END_TO_END_ADDED_P95_BUDGET_MS
+            ),
+            "end_to_end_p95_ratio_at_most_1_25": (
+                treatment_p95 / control_p95 <= END_TO_END_P95_RATIO_BUDGET
+                if control_p95
+                else False
+            ),
+            "path_index_within_storage_budget": (
+                index_operations["path_index_bytes"]
+                <= index_operations["path_index_budget_bytes"]
+            ),
+            "path_build_time_at_most_10_percent": bool(
+                index_operations["all_repositories_cold_indexed"]
+                and index_operations["path_build_time_ratio"] is not None
+                and index_operations["path_build_time_ratio"] <= PATH_BUILD_TIME_RATIO_BUDGET
+            ),
+        }
+        gates["passed"] = all(gates.values())
+
+        per_repository = {
+            repository_id: {
+                engine: retrieval_metrics(
+                    [
+                        row
+                        for row in rows
+                        if row["repository"] == repository_id and row["engine"] == engine
+                    ]
+                )
+                for engine in ENGINES
+            }
+            for repository_id in selected_ids
+        }
+        control_rows = [row for row in rows if row["engine"] == CONTROL_ENGINE]
+        baseline_comparison = (
+            _compare_baseline(control_rows, args.compare_baseline)
+            if args.compare_baseline
+            else None
+        )
+        metadata = build_run_metadata(
+            args.manifest,
+            "development",
+            revisions,
+            command=sys.argv,
+            seed=BASELINE_SEED,
+            extra={
+                "tier": args.tier,
+                "query_cases": len(cases),
+                "top_k": TOP_K,
+                "tessera_revision": tessera_revision,
+                "embedding_model": BASELINE_MODEL,
+                "engines": ENGINES,
+                "engine_order_rotated": True,
+                "path_rrf_weight": DEFAULT_RRF_WEIGHTS["path"],
+                "path_bm25_weights": ProjectDB.PATH_BM25_WEIGHTS,
+                "path_query_token_limit": PATH_QUERY_TOKEN_LIMIT,
+                "path_latency_repetitions": args.path_latency_repetitions,
+            },
+        )
+        output = {
+            "metadata": metadata,
+            "host": {"start": host_start, "end": _host_snapshot()},
+            "repositories": repository_metadata,
+            "summary": {
+                "primary_macro_per_repository": macro,
+                "pooled": {
+                    engine: retrieval_metrics([row for row in rows if row["engine"] == engine])
+                    for engine in ENGINES
+                },
+                "per_repository": per_repository,
+                "protected_segments": protected_segment_metrics(rows),
+                "protected_segment_deltas": protected_deltas,
+                "protected_regressions": protected_regressions,
+                "candidate_diagnostics": {
+                    engine: stratified_candidate_diagnostics(
+                        [row for row in rows if row["engine"] == engine]
+                    )
+                    for engine in ENGINES
+                },
+                "paired_candidate_recall": paired_candidate,
+                "paired_macro_mrr": paired_mrr,
+                "latency": latency,
+                "search_only_latency": search_latency,
+                "path_search_latency": path_latency,
+                "index_operations": index_operations,
+                "frozen_baseline_control_comparison": baseline_comparison,
+                "predeclared_gates": gates,
+            },
+            "queries": rows,
+            "limitations": [
+                "This is a public development treatment, not a sealed holdout result.",
+                "The natural-query corpus has only 30 cases and ceilinged baseline candidate recall.",
+                "File-level labels do not score the usefulness of the representative chunk.",
+                "Path rebuild time measures the derived sparse view in isolation; full indexing includes embeddings.",
+                "Host load is captured because end-to-end latency is sensitive to unrelated machine contention.",
+            ],
+        }
+        rendered = json.dumps(output, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered)
+    finally:
+        for database in databases.values():
+            database.close()
+        embedder.close()
+        ProjectDB.base_dir = None
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tessera/db/_project.py
+++ b/src/tessera/db/_project.py
@@ -10,7 +10,12 @@ from typing import Any
 import numpy as np
 
 from ..exceptions import PathTraversalError
-from ._utils import normalize_and_validate, sanitize_fts5_query
+from ._utils import (
+    build_path_fts_query,
+    build_path_search_fields,
+    normalize_and_validate,
+    sanitize_fts5_query,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +26,7 @@ class ProjectDB:
     # Default base directory for project databases.
     # Override via ProjectDB.base_dir for testing.
     base_dir: str | None = None
+    PATH_BM25_WEIGHTS = (4.0, 6.0, 6.0, 1.0, 2.0, 1.0)
 
     @staticmethod
     def _path_to_slug(project_path: str) -> str:
@@ -44,11 +50,11 @@ class ProjectDB:
         Args:
             project_path: Absolute path to the project root
         """
-        project_path = Path(os.path.abspath(project_path))
-        tessera_dir = self._get_data_dir(str(project_path))
+        project_root = Path(os.path.abspath(project_path))
+        tessera_dir = self._get_data_dir(str(project_root))
         tessera_dir.mkdir(parents=True, exist_ok=True)
 
-        self.project_path = project_path
+        self.project_path = project_root
         self.db_path = str(tessera_dir / "index.db")
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
@@ -60,7 +66,7 @@ class ProjectDB:
         self._create_schema()
         self._run_migrations()
 
-    CURRENT_SCHEMA_VERSION = 3
+    CURRENT_SCHEMA_VERSION = 4
 
     def _run_migrations(self):
         """Run schema migrations if needed."""
@@ -87,6 +93,9 @@ class ProjectDB:
 
         if current_version < 3:
             self._migrate_to_v3()
+
+        if current_version < 4:
+            self._migrate_to_v4()
 
         cursor.execute(
             "INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)",
@@ -129,6 +138,11 @@ class ProjectDB:
             else:
                 raise
         self.conn.commit()
+
+    def _migrate_to_v4(self):
+        """Migrate from schema v3 to v4: backfill searchable file paths."""
+        indexed = self.rebuild_file_path_index()
+        logger.info("Schema migration: indexed %d file paths", indexed)
 
     def get_meta(self, key: str) -> str | None:
         """Read a value from the _meta key-value store."""
@@ -349,6 +363,21 @@ class ProjectDB:
                 )
             """)
 
+            # Independent file-level path index. The chunk FTS path is
+            # intentionally UNINDEXED and cannot supply path-only candidates.
+            self.conn.execute("""
+                CREATE VIRTUAL TABLE IF NOT EXISTS file_paths_fts USING fts5(
+                    path,
+                    basename,
+                    stem,
+                    directories,
+                    module,
+                    aliases,
+                    file_id UNINDEXED,
+                    tokenize = 'unicode61 remove_diacritics 2'
+                )
+            """)
+
             # Embeddings table (BLOBs)
             self.conn.execute("""
                 CREATE TABLE IF NOT EXISTS chunk_embeddings (
@@ -374,6 +403,33 @@ class ProjectDB:
         return str(normalized)
 
     # File operations
+
+    def _searchable_relative_path(self, path: str) -> str:
+        """Return a stable project-relative path for sparse path indexing."""
+        validated = Path(self.validate_path(path))
+        return validated.relative_to(self.project_path.resolve()).as_posix()
+
+    def _replace_file_path_index(self, file_id: int, path: str) -> None:
+        fields = build_path_search_fields(self._searchable_relative_path(path))
+        self.conn.execute("DELETE FROM file_paths_fts WHERE file_id = ?", (file_id,))
+        self.conn.execute(
+            """
+            INSERT INTO file_paths_fts (
+                path, basename, stem, directories, module, aliases, file_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (*fields, file_id),
+        )
+
+    def rebuild_file_path_index(self) -> int:
+        """Rebuild derived path-search rows from the authoritative files table."""
+        rows = self.conn.execute("SELECT id, path FROM files ORDER BY id").fetchall()
+        with self.conn:
+            self.conn.execute("DELETE FROM file_paths_fts")
+            for row in rows:
+                self._replace_file_path_index(row["id"], row["path"])
+        return len(rows)
 
     def upsert_file(
         self,
@@ -409,7 +465,9 @@ class ProjectDB:
                 """,
                 (project_id, path, language, file_hash)
             )
-            return cursor.fetchone()[0]
+            file_id = cursor.fetchone()[0]
+            self._replace_file_path_index(file_id, path)
+            return file_id
 
     def get_file(
         self,
@@ -473,6 +531,7 @@ class ProjectDB:
         file_id = row["id"]
         self.clear_file_data(file_id)
         with self.conn:
+            self.conn.execute("DELETE FROM file_paths_fts WHERE file_id = ?", (file_id,))
             self.conn.execute("DELETE FROM files WHERE id = ?", (file_id,))
 
     def get_pending_files(self) -> list[dict[str, Any]]:
@@ -1186,6 +1245,70 @@ class ProjectDB:
                 LIMIT ?
                 """,
                 (query, limit)
+            )
+        return [dict(row) for row in cursor.fetchall()]
+
+    def path_search(
+        self,
+        query: str,
+        limit: int = 10,
+        source_type: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search independently indexed file paths and return chunk candidates.
+
+        Each matched file contributes its earliest eligible chunk. This keeps
+        the channel file-diverse while retaining the chunk identity expected by
+        the standard fusion pipeline.
+        """
+        if not query or not query.strip() or limit <= 0:
+            return []
+
+        fts_query = build_path_fts_query(query)
+        if not fts_query:
+            return []
+        bm25_weights = ", ".join(str(weight) for weight in self.PATH_BM25_WEIGHTS)
+
+        if source_type:
+            placeholders = ",".join("?" for _ in source_type)
+            cursor = self.conn.execute(
+                f"""
+                SELECT cm.*, files.path AS file_path,
+                       bm25(file_paths_fts, {bm25_weights}) AS score
+                FROM file_paths_fts
+                JOIN files ON files.id = CAST(file_paths_fts.file_id AS INTEGER)
+                JOIN chunk_meta cm ON cm.id = (
+                    SELECT eligible.id
+                    FROM chunk_meta eligible
+                    WHERE eligible.file_id = files.id
+                      AND COALESCE(eligible.source_type, 'code') IN ({placeholders})
+                    ORDER BY eligible.start_line, eligible.id
+                    LIMIT 1
+                )
+                WHERE file_paths_fts MATCH ?
+                ORDER BY score, files.path COLLATE NOCASE, files.path, cm.id
+                LIMIT ?
+                """,
+                (*source_type, fts_query, limit),
+            )
+        else:
+            cursor = self.conn.execute(
+                f"""
+                SELECT cm.*, files.path AS file_path,
+                       bm25(file_paths_fts, {bm25_weights}) AS score
+                FROM file_paths_fts
+                JOIN files ON files.id = CAST(file_paths_fts.file_id AS INTEGER)
+                JOIN chunk_meta cm ON cm.id = (
+                    SELECT eligible.id
+                    FROM chunk_meta eligible
+                    WHERE eligible.file_id = files.id
+                    ORDER BY eligible.start_line, eligible.id
+                    LIMIT 1
+                )
+                WHERE file_paths_fts MATCH ?
+                ORDER BY score, files.path COLLATE NOCASE, files.path, cm.id
+                LIMIT ?
+                """,
+                (fts_query, limit),
             )
         return [dict(row) for row in cursor.fetchall()]
 

--- a/src/tessera/db/_utils.py
+++ b/src/tessera/db/_utils.py
@@ -1,11 +1,86 @@
 """Shared database utilities: path validation and FTS5 query sanitization."""
 
 import logging
+import re
 from pathlib import Path
 
 from ..exceptions import PathTraversalError
 
 logger = logging.getLogger(__name__)
+
+PATH_QUERY_TOKEN_LIMIT = 32
+
+_IDENTIFIER_ATOM_RE = re.compile(r"[^\W_]+", re.UNICODE)
+_CAMEL_ACRONYM_BOUNDARY_RE = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_CAMEL_CASE_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_LETTER_DIGIT_BOUNDARY_RE = re.compile(r"(?<=[A-Za-z])(?=[0-9])|(?<=[0-9])(?=[A-Za-z])")
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def identifier_search_tokens(value: str) -> list[str]:
+    """Return stable exact and style-independent tokens for an identifier.
+
+    The transformation is deliberately language-agnostic. It preserves each
+    case-folded alphanumeric atom, splits camel/acronym/digit boundaries, and
+    adds the compact spelling so camel, snake, and kebab forms can meet in the
+    same sparse index.
+    """
+    atoms = _IDENTIFIER_ATOM_RE.findall(value)
+    tokens = [atom.casefold() for atom in atoms]
+    pieces: list[str] = []
+    for atom in atoms:
+        expanded = _CAMEL_ACRONYM_BOUNDARY_RE.sub(" ", atom)
+        expanded = _CAMEL_CASE_BOUNDARY_RE.sub(" ", expanded)
+        expanded = _LETTER_DIGIT_BOUNDARY_RE.sub(" ", expanded)
+        pieces.extend(piece.casefold() for piece in _IDENTIFIER_ATOM_RE.findall(expanded))
+    tokens.extend(pieces)
+    if pieces:
+        tokens.append("".join(pieces))
+    return _ordered_unique(tokens)
+
+
+def build_path_search_fields(path: str) -> tuple[str, str, str, str, str, str]:
+    """Build the six deterministic text views stored by ``file_paths_fts``."""
+    normalized = path.replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.strip("/")
+
+    components = [component for component in normalized.split("/") if component]
+    basename = components[-1] if components else normalized
+    if basename.startswith(".") and basename.count(".") == 1:
+        stem = basename
+    elif "." in basename:
+        stem = basename.rsplit(".", 1)[0]
+    else:
+        stem = basename
+    directories = " ".join(components[:-1])
+    module_components = [*components[:-1], stem] if stem else components[:-1]
+    module = ".".join(module_components)
+
+    aliases: list[str] = []
+    for component in components:
+        aliases.extend(identifier_search_tokens(component))
+    aliases.extend(identifier_search_tokens(stem))
+    alias_text = " ".join(_ordered_unique(aliases))
+    return normalized, basename, stem, directories, module, alias_text
+
+
+def build_path_fts_query(query: str) -> str:
+    """Build a bounded literal OR query for the path FTS channel."""
+    tokens = identifier_search_tokens(query)[:PATH_QUERY_TOKEN_LIMIT]
+    return " OR ".join(f'"{token}"' for token in tokens)
 
 
 def normalize_and_validate(project_root: Path, user_path: str) -> Path:

--- a/src/tessera/search.py
+++ b/src/tessera/search.py
@@ -24,7 +24,7 @@ import os
 import re
 from collections.abc import Callable
 from enum import StrEnum
-from typing import Optional
+from typing import Optional, cast
 
 import faiss
 import numpy as np
@@ -111,6 +111,7 @@ BM25_STRONG_SIGNAL_GAP = 0.15
 # Per-list weights for weighted RRF fusion
 DEFAULT_RRF_WEIGHTS = {
     "keyword": 1.0,
+    "path": 1.2,
     "semantic": 1.2,
     "graph": 0.8,
 }
@@ -692,17 +693,19 @@ def hybrid_search(
     depth_penalty: float = 0.0,
     file_dedup: bool = False,
     trace: SearchTrace | None = None,
+    enable_path_search: bool = True,
 ) -> list[dict]:
     """
     Hybrid search combining keyword (FTS5) and semantic (vector) results.
 
     Algorithm:
     1. Run FTS5 keyword search via db.keyword_search()
-    2. If query_embedding provided: run cosine_search on db.get_all_embeddings()
-    3. Merge with weighted RRF
-    4. Apply optional post-merge boosts (filename, symbol, depth)
-    5. Optionally dedup by file (keep best chunk per file)
-    6. Enrich results with file_path, start_line, end_line from chunk_meta
+    2. Run the independently indexed file/path candidate channel when available
+    3. If query_embedding provided: run cosine_search on db.get_all_embeddings()
+    4. Merge with weighted RRF
+    5. Apply optional post-merge boosts (filename, symbol, depth)
+    6. Optionally dedup by file (keep best chunk per file)
+    7. Enrich results with file_path, start_line, end_line from chunk_meta
 
     Args:
         query: Search query string
@@ -716,6 +719,7 @@ def hybrid_search(
         filename_boost: Optional post-merge score per query-token/filename overlap
         file_dedup: Keep only the best-scoring chunk per file
         trace: Optional diagnostic collector; omitted from normal result payloads
+        enable_path_search: Run the path channel when lexical retrieval is routed
     """
     original_query = query
 
@@ -745,6 +749,7 @@ def hybrid_search(
                 "query_expansion": query_expansion,
                 "depth_penalty": depth_penalty,
                 "file_dedup": file_dedup,
+                "enable_path_search": enable_path_search,
                 "graph_available": graph is not None,
             },
         )
@@ -822,7 +827,62 @@ def hybrid_search(
             score_kind="fts5_bm25",
         )
 
-    # 1b. BM25 strong-signal short-circuit: skip expensive operations when
+    # 1b. Independently indexed file/path candidates. Older DB-like adapters
+    # remain valid: an unavailable capability is treated as a skipped channel.
+    path_results: list[dict] = []
+    path_search = getattr(db, "path_search", None)
+    if enable_path_search and run_keyword and callable(path_search):
+        path_limit = limit
+        try:
+            path_results = cast(
+                list[dict],
+                path_search(
+                    query,
+                    limit=path_limit,
+                    source_type=source_type,
+                ),
+            )
+            if trace is not None:
+                trace.record_channel(
+                    "path",
+                    path_results,
+                    score_kind="fts5_path_bm25",
+                    metadata=_trace_candidate_metadata(db, path_results),
+                    normalized_scores={
+                        item["id"]: normalize_bm25_score(item.get("score", 0.0))
+                        for item in path_results
+                    },
+                    requested_limit=path_limit,
+                )
+            if path_results:
+                ranked_lists.append(path_results)
+                list_labels.append("path")
+        except Exception as error:
+            path_results = []
+            if trace is not None:
+                trace.error("path", error)
+                trace.channel_status(
+                    "path",
+                    "error",
+                    reason="path_search_failed",
+                    requested_limit=path_limit,
+                    score_kind="fts5_path_bm25",
+                )
+    elif trace is not None:
+        if not enable_path_search:
+            reason = "disabled"
+        elif not run_keyword:
+            reason = "query_routing"
+        else:
+            reason = "capability_unavailable"
+        trace.channel_status(
+            "path",
+            "skipped",
+            reason=reason,
+            score_kind="fts5_path_bm25",
+        )
+
+    # 1c. BM25 strong-signal short-circuit: skip expensive operations when
     # keyword match is very high confidence (top score >= 0.85 with >= 0.15 gap)
     initial_strong_keyword_signal = bool(
         keyword_results and bm25_strong_signal_check(keyword_results)
@@ -874,10 +934,10 @@ def hybrid_search(
                 reason="bm25_short_circuit",
                 score_kind="ppr",
             )
-        weights = [effective_weights.get("keyword", 1.0)]
+        weights = [effective_weights.get(label, 1.0) for label in list_labels]
         merged = weighted_rrf_merge(ranked_lists, weights=weights)
         if trace is not None:
-            trace.record_fusion(merged, labels=["keyword"], weights=weights)
+            trace.record_fusion(merged, labels=list_labels, weights=weights)
         if file_dedup:
             before_dedup = merged
             merged = _dedupe_ranked_by_file(before_dedup, db)
@@ -906,7 +966,7 @@ def hybrid_search(
                     "end_line": meta.get("end_line", 0),
                     "content": meta.get("content", ""),
                     "score": item.get("rrf_score", item.get("score", 0.0)),
-                    "rank_sources": ["keyword"],
+                    "rank_sources": list_labels,
                     "source_type": chunk_source_type,
                     "trusted": chunk_source_type == "code",
                     "section_heading": meta.get("section_heading", ""),
@@ -924,7 +984,7 @@ def hybrid_search(
                     "end_line": 0,
                     "content": "",
                     "score": item.get("rrf_score", item.get("score", 0.0)),
-                    "rank_sources": ["keyword"],
+                    "rank_sources": list_labels,
                     "source_type": "code",
                     "trusted": True,
                     "section_heading": "",

--- a/tests/performance/test_search_benchmark.py
+++ b/tests/performance/test_search_benchmark.py
@@ -703,9 +703,9 @@ class TestStructuredQueries:
 
         report_lines.append("")
 
-    def test_lex_only_matches_keyword_search(self, db, report_lines):
-        """LEX-only results should match db.keyword_search() exactly."""
-        report_lines.append("**LEX-only vs keyword_search():**")
+    def test_lex_content_control_matches_keyword_search(self, db, report_lines):
+        """The path-disabled LEX control should match content FTS exactly."""
+        report_lines.append("**Path-disabled LEX vs keyword_search():**")
         report_lines.append("")
         report_lines.append("| Query | LEX Top-5 IDs | keyword_search Top-5 IDs | Match? |")
         report_lines.append("|-------|--------------|-------------------------|--------|")
@@ -715,6 +715,7 @@ class TestStructuredQueries:
             lex_results = hybrid_search(
                 query, query_embedding=None, db=db, limit=5,
                 search_types=[SearchType.LEX],
+                enable_path_search=False,
             )
 
             # Direct keyword_search (with same sanitization)

--- a/tests/unit/test_benchmark_governance.py
+++ b/tests/unit/test_benchmark_governance.py
@@ -15,6 +15,7 @@ from scripts.benchmark_governance import (
     load_queries,
     macro_per_repository,
     paired_bootstrap_interval,
+    paired_candidate_recall_interval,
     protected_segment_metrics,
     repositories_for_split,
     validate_labels_against_checkout,
@@ -131,6 +132,33 @@ def test_paired_bootstrap_rejects_unpaired_cases() -> None:
     ]
     with pytest.raises(CorpusValidationError, match="different cases"):
         paired_bootstrap_interval(rows, "baseline", "candidate", iterations=10)
+
+
+def test_paired_candidate_recall_interval_uses_repository_pairs() -> None:
+    rows = []
+    for repository in ("repo-a", "repo-b"):
+        for case_id in ("one", "two"):
+            for engine, recall in (("baseline", 0.0), ("candidate", 1.0)):
+                row = _row(engine, repository, case_id, 1)
+                row["candidate_diagnostics"] = {
+                    "union": {"recall_at_k": {"10": recall}}
+                }
+                rows.append(row)
+
+    result = paired_candidate_recall_interval(
+        rows,
+        "baseline",
+        "candidate",
+        cutoff=10,
+        iterations=500,
+        seed=7,
+    )
+
+    assert result["metric"] == "macro_union_candidate_recall_at_10_delta"
+    assert result["repositories"] == 2
+    assert result["paired_queries"] == 4
+    assert result["delta"] == 1.0
+    assert result["ci_lower"] == 1.0
 
 
 def test_run_metadata_binds_split_manifest_and_revisions() -> None:

--- a/tests/unit/test_path_search.py
+++ b/tests/unit/test_path_search.py
@@ -1,0 +1,234 @@
+"""Invariant tests for the independent file/path candidate channel."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tessera.db import ProjectDB
+from tessera.search import SearchType, hybrid_search
+from tessera.search_trace import SearchTrace
+
+
+def _add_chunk(
+    db: ProjectDB,
+    path: str,
+    *,
+    content: str = "opaque implementation body",
+    source_type: str = "code",
+) -> int:
+    file_id = db.upsert_file(1, path, "document" if source_type == "markdown" else "python", "hash")
+    return db.insert_chunks(
+        [
+            {
+                "project_id": 1,
+                "file_id": file_id,
+                "start_line": 1,
+                "end_line": 2,
+                "symbol_ids": [],
+                "ast_type": "document" if source_type == "markdown" else "module",
+                "chunk_type": "document" if source_type == "markdown" else "code",
+                "content": content,
+                "source_type": source_type,
+                "file_path": path,
+            }
+        ]
+    )[0]
+
+
+def test_path_only_identifier_aliases_are_searchable(tmp_path) -> None:
+    db = ProjectDB(str(tmp_path))
+    target_id = _add_chunk(db, "src/network/HTTPResponseCache.ts")
+
+    assert db.keyword_search("http response cache") == []
+    for query in (
+        "http response cache",
+        "HTTPResponseCache",
+        "http-response-cache",
+        "http_response_cache",
+        "SRC/NETWORK/httpresponsecache.TS",
+    ):
+        results = db.path_search(query, limit=5)
+        assert results and results[0]["id"] == target_id
+        assert results[0]["file_path"] == "src/network/HTTPResponseCache.ts"
+
+
+def test_duplicate_basenames_and_generated_vendor_paths_remain_distinct(tmp_path) -> None:
+    db = ProjectDB(str(tmp_path))
+    source_id = _add_chunk(db, "src/api/ConfigLoader.py")
+    generated_id = _add_chunk(db, "vendor/generated/ConfigLoader.py")
+
+    basename_results = db.path_search("config loader", limit=10)
+    assert [row["id"] for row in basename_results] == [source_id, generated_id]
+
+    generated_results = db.path_search("generated config loader", limit=10)
+    assert generated_results[0]["id"] == generated_id
+    assert {row["id"] for row in generated_results} == {source_id, generated_id}
+
+
+def test_path_search_respects_source_type_and_selects_one_chunk_per_file(tmp_path) -> None:
+    db = ProjectDB(str(tmp_path))
+    code_id = _add_chunk(db, "src/RunBook.py", source_type="code")
+    markdown_id = _add_chunk(db, "docs/RunBook.md", source_type="markdown")
+    markdown_file = db.get_chunk(markdown_id)["file_id"]
+    second_markdown_id = db.insert_chunks(
+        [
+            {
+                "project_id": 1,
+                "file_id": markdown_file,
+                "start_line": 20,
+                "end_line": 25,
+                "symbol_ids": [],
+                "ast_type": "document",
+                "chunk_type": "document",
+                "content": "another opaque section",
+                "source_type": "markdown",
+                "file_path": "docs/RunBook.md",
+            }
+        ]
+    )[0]
+
+    code = db.path_search("run book", limit=10, source_type=["code"])
+    docs = db.path_search("run book", limit=10, source_type=["markdown"])
+
+    assert [row["id"] for row in code] == [code_id]
+    assert [row["id"] for row in docs] == [markdown_id]
+    assert second_markdown_id not in {row["id"] for row in docs}
+
+
+def test_path_index_is_idempotent_and_deleted_with_file(tmp_path) -> None:
+    db = ProjectDB(str(tmp_path))
+    path = "src/RequestRouter.go"
+    file_id = db.upsert_file(1, path, "go", "first")
+    db.upsert_file(1, path, "go", "second")
+
+    rows = db.conn.execute(
+        "SELECT file_id FROM file_paths_fts WHERE file_id = ?",
+        (file_id,),
+    ).fetchall()
+    assert len(rows) == 1
+
+    _add_chunk(db, "src/OtherRouter.go")
+    db.delete_file_data(path)
+    rows = db.conn.execute(
+        "SELECT file_id FROM file_paths_fts WHERE file_id = ?",
+        (file_id,),
+    ).fetchall()
+    assert rows == []
+
+
+def test_v3_database_is_backfilled_on_open(tmp_path) -> None:
+    db = ProjectDB(str(tmp_path))
+    target_id = _add_chunk(db, "docs/DeploymentPlaybook.md", source_type="markdown")
+    db.conn.execute("DROP TABLE file_paths_fts")
+    db.conn.execute("INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', '3')")
+    db.conn.commit()
+    db.close()
+
+    migrated = ProjectDB(str(tmp_path))
+    assert migrated.get_meta("schema_version") == "4"
+    results = migrated.path_search("deployment playbook", limit=5)
+    assert [row["id"] for row in results] == [target_id]
+
+
+def test_hybrid_path_channel_recovers_candidate_absent_from_content_lists() -> None:
+    class FakeDB:
+        chunks = {
+            **{
+                chunk_id: {
+                    "id": chunk_id,
+                    "file_id": chunk_id,
+                    "file_path": f"src/distractor_{chunk_id}.py",
+                    "source_type": "code",
+                    "content": "distractor",
+                }
+                for chunk_id in range(1, 11)
+            },
+            99: {
+                "id": 99,
+                "file_id": 99,
+                "file_path": "src/HTTPResponseCache.ts",
+                "source_type": "code",
+                "content": "opaque",
+            },
+        }
+
+        def keyword_search(self, *_args, **_kwargs):
+            return []
+
+        def path_search(self, *_args, **_kwargs):
+            return [{"id": 99, "score": -8.0}]
+
+        def get_all_embeddings(self):
+            return list(range(1, 11)), np.array(
+                [[1.0, 0.0] for _ in range(10)],
+                dtype=np.float32,
+            )
+
+        def get_chunk(self, chunk_id):
+            return dict(self.chunks[chunk_id])
+
+    control = hybrid_search(
+        "http response cache",
+        np.array([1.0, 0.0], dtype=np.float32),
+        FakeDB(),
+        limit=10,
+        enable_path_search=False,
+    )
+    trace = SearchTrace(project_name="path-fixture")
+    treatment = hybrid_search(
+        "http response cache",
+        np.array([1.0, 0.0], dtype=np.float32),
+        FakeDB(),
+        limit=10,
+        trace=trace,
+    )
+
+    assert 99 not in {row["id"] for row in control}
+    assert treatment[0]["id"] == 99
+    assert trace.channels["path"]["status"] == "used"
+    assert trace.candidates["path-fixture:99"]["channels"]["path"]["rank"] == 1
+    assert trace.validate_complete_attribution() == []
+
+
+def test_no_path_match_preserves_control_order_and_legacy_db_capability() -> None:
+    class LegacyDB:
+        chunks = {
+            1: {"id": 1, "file_id": 1, "file_path": "a.py", "content": "a"},
+            2: {"id": 2, "file_id": 2, "file_path": "b.py", "content": "b"},
+        }
+
+        def keyword_search(self, *_args, **_kwargs):
+            return [{"id": 1, "score": -0.2}, {"id": 2, "score": -0.1}]
+
+        def get_chunk(self, chunk_id):
+            return dict(self.chunks[chunk_id])
+
+    class EmptyPathDB(LegacyDB):
+        def path_search(self, *_args, **_kwargs):
+            return []
+
+    expected = hybrid_search(
+        "unrelated query",
+        None,
+        EmptyPathDB(),
+        limit=2,
+        search_types=[SearchType.LEX],
+        enable_path_search=False,
+    )
+    actual = hybrid_search(
+        "unrelated query",
+        None,
+        EmptyPathDB(),
+        limit=2,
+        search_types=[SearchType.LEX],
+    )
+    legacy = hybrid_search(
+        "unrelated query",
+        None,
+        LegacyDB(),
+        limit=2,
+        search_types=[SearchType.LEX],
+    )
+
+    assert actual == expected
+    assert legacy == expected

--- a/tests/unit/test_schema_migration.py
+++ b/tests/unit/test_schema_migration.py
@@ -1,14 +1,14 @@
-"""Tests for schema migration v1 → v2."""
+"""Tests for ProjectDB schema creation and migrations."""
 import tempfile
 
 from tessera.db import ProjectDB
 
 
 class TestSchemaMigration:
-    def test_fresh_db_has_v2_schema(self):
+    def test_fresh_db_has_current_schema(self):
         db = ProjectDB(tempfile.mkdtemp())
         cur = db.conn.execute("SELECT value FROM _meta WHERE key='schema_version'")
-        assert cur.fetchone()[0] == "3"
+        assert cur.fetchone()[0] == "4"
 
     def test_new_columns_exist(self):
         db = ProjectDB(tempfile.mkdtemp())
@@ -20,7 +20,7 @@ class TestSchemaMigration:
         db = ProjectDB(tempfile.mkdtemp())
         db._run_migrations()  # Should not raise
         cur = db.conn.execute("SELECT value FROM _meta WHERE key='schema_version'")
-        assert cur.fetchone()[0] == "3"
+        assert cur.fetchone()[0] == "4"
 
     def test_source_type_defaults_to_code(self):
         db = ProjectDB(tempfile.mkdtemp())


### PR DESCRIPTION
## Hypothesis

A separate file-level path index can recover files whose names or module paths match a query even when their bodies do not, without repository- or benchmark-specific behavior.

## Frozen treatment

- schema v4 FTS5 path index for normalized path, basename, stem, directories, module, and identifier aliases
- transactional upsert/delete, v3 backfill, and rebuild support
- path candidates fused through weighted RRF; no post-fusion filename boost
- explicit path-channel ablation for paired control/treatment evidence
- generic invented fixtures for aliases, punctuation, duplicate basenames, generated/vendor paths, source filters, migration, deletion, and legacy adapters

The hypothesis, constants, operational budgets, and merge gates were committed before treatment in `docs/plans/retrieval-quality-master-plan/PR-04.md`.

## Validation so far

- red control: 9 expected failures before implementation
- green treatment: 12/12 path and migration invariants
- 501 unit tests pass
- 209 focused search/index/server/graph/asset/cross-file/federation integration tests pass
- scoped Ruff and Pyright pass; strict MkDocs build passes
- one-repository smoke run found one quality regression, so no constants will be retuned

## Benchmark status

The frozen six-repository development run is being restarted across Python, TypeScript/JavaScript, PHP, Go, Swift, Ruby, code, Markdown/document, and mixed queries. Machine-readable results and the decision report will be committed here.

## Merge status

Draft / do not merge until every predeclared gate is evaluated. An inconclusive or negative result stays unmerged.